### PR TITLE
Add DMCA policy page and certification checkboxes

### DIFF
--- a/app/Filament/Resources/CardResource.php
+++ b/app/Filament/Resources/CardResource.php
@@ -10,6 +10,7 @@ use BackedEnum;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
+use Filament\Forms\Components\Checkbox;
 use Filament\Forms\Components\FileUpload;
 use Filament\Forms\Components\TextInput;
 use Filament\Resources\Resource;
@@ -37,6 +38,10 @@ class CardResource extends Resource
                     ->required()
                     ->directory('cards')
                     ->image(),
+                Checkbox::make('dmca_certification')
+                    ->label('I certify that I own this image or have a legitimate license/permission to share it. I understand that Knuckleball follows a strict DMCA policy and will remove infringing content and terminate repeat infringer accounts.')
+                    ->rules(['accepted'])
+                    ->dehydrated(false),
             ]);
     }
 

--- a/app/Filament/Resources/PlayerResource.php
+++ b/app/Filament/Resources/PlayerResource.php
@@ -18,6 +18,7 @@ use Filament\Actions\DeleteAction;
 use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
 use Filament\Actions\ImportAction;
+use Filament\Forms\Components\Checkbox;
 use Filament\Forms\Components\DatePicker;
 use Filament\Forms\Components\FileUpload;
 use Filament\Forms\Components\Select;
@@ -66,6 +67,10 @@ class PlayerResource extends Resource
                 FileUpload::make('url')
                     ->directory('avatars')
                     ->avatar(),
+                Checkbox::make('dmca_certification')
+                    ->label('I certify that I own this image or have a legitimate license/permission to share it. I understand that Knuckleball follows a strict DMCA policy and will remove infringing content and terminate repeat infringer accounts.')
+                    ->rules(['accepted'])
+                    ->dehydrated(false),
             ]);
     }
 

--- a/app/Filament/Resources/TeamResource.php
+++ b/app/Filament/Resources/TeamResource.php
@@ -11,6 +11,7 @@ use Filament\Actions\Action;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
+use Filament\Forms\Components\Checkbox;
 use Filament\Forms\Components\DatePicker;
 use Filament\Forms\Components\FileUpload;
 use Filament\Forms\Components\Select;
@@ -40,6 +41,10 @@ class TeamResource extends Resource
                 FileUpload::make('url')
                     ->directory('teams')
                     ->avatar(),
+                Checkbox::make('dmca_certification')
+                    ->label('I certify that I own this image or have a legitimate license/permission to share it. I understand that Knuckleball follows a strict DMCA policy and will remove infringing content and terminate repeat infringer accounts.')
+                    ->rules(['accepted'])
+                    ->dehydrated(false),
             ]);
     }
 

--- a/app/Livewire/ViewPlayers.php
+++ b/app/Livewire/ViewPlayers.php
@@ -9,6 +9,7 @@ use Filament\Actions\Concerns\InteractsWithActions;
 use Filament\Actions\Contracts\HasActions;
 use Filament\Actions\CreateAction;
 use Filament\Actions\EditAction;
+use Filament\Forms\Components\Checkbox;
 use Filament\Forms\Components\DatePicker;
 use Filament\Forms\Components\FileUpload;
 use Filament\Forms\Components\Select;
@@ -130,6 +131,10 @@ class ViewPlayers extends Component implements HasActions, HasForms, HasTable
                     ->directory('avatars')
                     ->nullable()
                     ->avatar(),
+                Checkbox::make('dmca_certification')
+                    ->label('I certify that I own this image or have a legitimate license/permission to share it. I understand that Knuckleball follows a strict DMCA policy and will remove infringing content and terminate repeat infringer accounts.')
+                    ->rules(['accepted'])
+                    ->dehydrated(false),
             ])
             ->using(function (array $data): Model {
                 $data = collect($data);

--- a/database/migrations/2026_04_17_143725_make_note_nullable_on_players_table.php
+++ b/database/migrations/2026_04_17_143725_make_note_nullable_on_players_table.php
@@ -1,0 +1,18 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('players', function (Blueprint $table) {
+            $table->text('note')->nullable()->change();
+        });
+    }
+};

--- a/database/migrations/2026_04_17_143725_make_note_nullable_on_players_table.php
+++ b/database/migrations/2026_04_17_143725_make_note_nullable_on_players_table.php
@@ -6,9 +6,6 @@ use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
-    /**
-     * Run the migrations.
-     */
     public function up(): void
     {
         Schema::table('players', function (Blueprint $table) {

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -70,6 +70,22 @@
     }
 }
 
+.prose-reset {
+    & h1, & h2, & h3, & h4 {
+        font-family: ui-sans-serif, system-ui, sans-serif;
+        letter-spacing: normal;
+        font-weight: 600;
+    }
+
+    & h1 { font-size: 1.875rem; line-height: 2.25rem; margin-bottom: 1rem; }
+    & h2 { font-size: 1.25rem; line-height: 1.75rem; margin-top: 1.75rem; margin-bottom: 0.5rem; }
+
+    & p { line-height: 1.75; margin-bottom: 1.25rem; }
+
+    & ol { padding-left: 1.5rem; list-style-type: decimal; }
+    & li { line-height: 1.75; margin-bottom: 0.5rem; }
+}
+
 .tag {
     display: inline-block;
     margin: 10px;

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -66,6 +66,9 @@
             @endif
 
             <div class="flex items-center justify-end mt-4 gap-4">
+                <a class="underline text-sm text-gray-600 hover:text-gray-900 rounded-md focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500" href="{{ route('dmca') }}" target="_blank">
+                    {{ __('DMCA Policy') }}
+                </a>
                 <a class="underline text-sm text-gray-600 hover:text-gray-900 rounded-md focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500" href="{{ route('login') }}">
                     {{ __('Already registered?') }}
                 </a>

--- a/resources/views/dmca.blade.php
+++ b/resources/views/dmca.blade.php
@@ -1,0 +1,38 @@
+<x-guest-layout>
+    <div class="pt-4 bg-gray-100">
+        <div class="min-h-screen flex flex-col items-center pt-6 sm:pt-0">
+            <div>
+                <x-authentication-card-logo />
+            </div>
+
+            <div class="w-full sm:max-w-2xl mt-6 p-6 bg-white shadow-md overflow-hidden sm:rounded-lg prose">
+                <h1>Digital Millennium Copyright Act (DMCA) Policy</h1>
+
+                <p>Knuckleball respects the intellectual property rights of others and expects its users to do the same. In accordance with the Digital Millennium Copyright Act (DMCA), we will respond expeditiously to notices of alleged infringement that are reported to our Designated Agent.</p>
+
+                <h2>Reporting Infringement</h2>
+
+                <p>If you are a copyright owner and believe your work is being infringed on Knuckleball, please send a written notification to our Designated Agent. Your notice must include:</p>
+
+                <ol>
+                    <li>Identification of the copyrighted work claimed to have been infringed.</li>
+                    <li>Identification of the material that is claimed to be infringing (including the specific URL).</li>
+                    <li>Your contact information (address, telephone number, and email).</li>
+                    <li>A statement that you have a "good faith belief" that the use of the material is not authorized by the copyright owner, its agent, or the law.</li>
+                    <li>A statement, under penalty of perjury, that the information in the notification is accurate and that you are authorized to act on behalf of the owner.</li>
+                </ol>
+
+                <h2>Designated Agent</h2>
+
+                <p>
+                    <strong>Attn:</strong> Knuckleball Compliance<br>
+                    <strong>Email:</strong> <a href="mailto:hello@knuckleball.app">hello@knuckleball.app</a>
+                </p>
+
+                <h2>Repeat Infringer Policy</h2>
+
+                <p>In accordance with the DMCA and other applicable law, Knuckleball has adopted a policy of terminating, in appropriate circumstances and at Knuckleball's sole discretion, users who are deemed to be repeat infringers.</p>
+            </div>
+        </div>
+    </div>
+</x-guest-layout>

--- a/resources/views/dmca.blade.php
+++ b/resources/views/dmca.blade.php
@@ -1,38 +1,32 @@
-<x-guest-layout>
-    <div class="pt-4 bg-gray-100">
-        <div class="min-h-screen flex flex-col items-center pt-6 sm:pt-0">
-            <div>
-                <x-authentication-card-logo />
-            </div>
+<x-app-layout>
+    <div class="max-w-2xl mx-auto px-4 py-12">
+        <div class="bg-white shadow-md rounded-lg p-6 prose-reset">
+            <h1>Digital Millennium Copyright Act (DMCA) Policy</h1>
 
-            <div class="w-full sm:max-w-2xl mt-6 p-6 bg-white shadow-md overflow-hidden sm:rounded-lg prose">
-                <h1>Digital Millennium Copyright Act (DMCA) Policy</h1>
+            <p>Knuckleball respects the intellectual property rights of others and expects its users to do the same. In accordance with the Digital Millennium Copyright Act (DMCA), we will respond expeditiously to notices of alleged infringement that are reported to our Designated Agent.</p>
 
-                <p>Knuckleball respects the intellectual property rights of others and expects its users to do the same. In accordance with the Digital Millennium Copyright Act (DMCA), we will respond expeditiously to notices of alleged infringement that are reported to our Designated Agent.</p>
+            <h2>Reporting Infringement</h2>
 
-                <h2>Reporting Infringement</h2>
+            <p>If you are a copyright owner and believe your work is being infringed on Knuckleball, please send a written notification to our Designated Agent. Your notice must include:</p>
 
-                <p>If you are a copyright owner and believe your work is being infringed on Knuckleball, please send a written notification to our Designated Agent. Your notice must include:</p>
+            <ol>
+                <li>Identification of the copyrighted work claimed to have been infringed.</li>
+                <li>Identification of the material that is claimed to be infringing (including the specific URL).</li>
+                <li>Your contact information (address, telephone number, and email).</li>
+                <li>A statement that you have a "good faith belief" that the use of the material is not authorized by the copyright owner, its agent, or the law.</li>
+                <li>A statement, under penalty of perjury, that the information in the notification is accurate and that you are authorized to act on behalf of the owner.</li>
+            </ol>
 
-                <ol>
-                    <li>Identification of the copyrighted work claimed to have been infringed.</li>
-                    <li>Identification of the material that is claimed to be infringing (including the specific URL).</li>
-                    <li>Your contact information (address, telephone number, and email).</li>
-                    <li>A statement that you have a "good faith belief" that the use of the material is not authorized by the copyright owner, its agent, or the law.</li>
-                    <li>A statement, under penalty of perjury, that the information in the notification is accurate and that you are authorized to act on behalf of the owner.</li>
-                </ol>
+            <h2>Designated Agent</h2>
 
-                <h2>Designated Agent</h2>
+            <p>
+                <strong>Attn:</strong> Knuckleball Compliance<br>
+                <strong>Email:</strong> <a href="mailto:hello@knuckleball.app">hello@knuckleball.app</a>
+            </p>
 
-                <p>
-                    <strong>Attn:</strong> Knuckleball Compliance<br>
-                    <strong>Email:</strong> <a href="mailto:hello@knuckleball.app">hello@knuckleball.app</a>
-                </p>
+            <h2>Repeat Infringer Policy</h2>
 
-                <h2>Repeat Infringer Policy</h2>
-
-                <p>In accordance with the DMCA and other applicable law, Knuckleball has adopted a policy of terminating, in appropriate circumstances and at Knuckleball's sole discretion, users who are deemed to be repeat infringers.</p>
-            </div>
+            <p>In accordance with the DMCA and other applicable law, Knuckleball has adopted a policy of terminating, in appropriate circumstances and at Knuckleball's sole discretion, users who are deemed to be repeat infringers.</p>
         </div>
     </div>
-</x-guest-layout>
+</x-app-layout>

--- a/resources/views/landing.blade.php
+++ b/resources/views/landing.blade.php
@@ -208,7 +208,8 @@
 					<li><a href="https://www.instagram.com/knuckleballapp/" class="fa fa-instagram wow fadeIn" data-wow-delay="0.9s"></a></li>
 				</ul>
 				<hr>
-				<p><b>Copyright © 2025 Knuckleball  | All right Reserved | Made in the USA </p></b>
+				<p><b>Copyright © 2025 Knuckleball  | All right Reserved | Made in the USA</b></p>
+				<p><a href="{{ route('dmca') }}" style="color: inherit;">DMCA Policy</a></p>
 			</div>
 
 		</div>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -21,12 +21,19 @@
     <body class="font-sans antialiased">
         <x-banner />
 
-        <div class="min-h-screen">
+        <div class="min-h-screen flex flex-col">
             @livewire('navigation-menu')
 
-            <!-- Page Heading -->
+            <main class="grow">
+                {{ $slot }}
+            </main>
 
-            {{ $slot }}
+            <footer class="border-t border-gray-200 bg-white">
+                <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex flex-wrap items-center justify-between gap-2 text-sm text-gray-500">
+                    <span>&copy; {{ date('Y') }} Knuckleball. All rights reserved.</span>
+                    <a href="{{ route('dmca') }}" class="hover:text-gray-700 underline">DMCA Policy</a>
+                </div>
+            </footer>
         </div>
 
         @stack('modals')

--- a/routes/web.php
+++ b/routes/web.php
@@ -12,6 +12,7 @@ use App\Livewire\ViewTeams;
 use Illuminate\Support\Facades\Route;
 
 Route::view('/', 'landing')->name('home');
+Route::view('dmca', 'dmca')->name('dmca');
 Route::livewire('feed', UserFeed::class)->name('users.feed');
 Route::livewire('teams', ViewTeams::class)->name('teams.index');
 Route::livewire('categories/{category}/teams', ViewTeams::class)->name('categories.teams.index');

--- a/tests/Feature/Filament/Resources/PlayerResourceTest.php
+++ b/tests/Feature/Filament/Resources/PlayerResourceTest.php
@@ -39,6 +39,7 @@ it('can create a player', function () {
         'name' => 'Test Player',
         'team_id' => $team->id,
         'note' => 'Test note',
+        'dmca_certification' => true,
     ];
 
     Livewire::test(PlayerResource\Pages\CreatePlayer::class)
@@ -91,6 +92,7 @@ it('can update a player', function () {
         'name' => 'Updated Name',
         'team_id' => $team->id,
         'note' => 'Updated note',
+        'dmca_certification' => true,
     ];
 
     Livewire::test(PlayerResource\Pages\EditPlayer::class, [
@@ -210,6 +212,7 @@ it('can set dates for player', function () {
             'published_at' => $publishedAt,
             'retired_at' => $retiredAt,
             'deceased_at' => $deceasedAt,
+            'dmca_certification' => true,
         ])
         ->call('create')
         ->assertHasNoFormErrors();
@@ -231,6 +234,7 @@ it('can associate player with user', function () {
             'name' => 'Test Player',
             'team_id' => $team->id,
             'user_id' => $user->id,
+            'dmca_certification' => true,
         ])
         ->call('create')
         ->assertHasNoFormErrors();


### PR DESCRIPTION
## Summary

- Adds a DMCA certification checkbox (must be accepted) to all Filament image upload forms — Player, Team, and Card resources — as well as the public New Player modal
- Creates a `/dmca` page using the app layout (nav + footer) with a scoped `prose-reset` CSS class to override the global display font
- Adds DMCA Policy links to the landing page footer, main app footer (new), and the registration page
- Fixes the New Player modal failing due to `note` not being nullable on the `players` table

## Test plan

- [ ] Upload an image in the Player, Team, or Card admin forms without checking the checkbox — should block submission
- [ ] Check the checkbox and submit — should succeed
- [ ] Open the New Player modal on `/players`, submit without checking — should block
- [ ] Visit `/dmca` — should show the full policy page with nav and footer
- [ ] Verify DMCA Policy link appears in the landing page footer, app footer, and register page

🤖 Generated with [Claude Code](https://claude.com/claude-code)