### PR TITLE
Make DMCA certification conditional on image upload

### DIFF
--- a/app/Filament/Resources/PlayerResource.php
+++ b/app/Filament/Resources/PlayerResource.php
@@ -25,6 +25,7 @@ use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Resources\Resource;
+use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Schema;
 use Filament\Tables\Columns\CheckboxColumn;
 use Filament\Tables\Columns\ImageColumn;
@@ -69,7 +70,7 @@ class PlayerResource extends Resource
                     ->avatar(),
                 Checkbox::make('dmca_certification')
                     ->label('I certify that I own this image or have a legitimate license/permission to share it. I understand that Knuckleball follows a strict DMCA policy and will remove infringing content and terminate repeat infringer accounts.')
-                    ->rules(['accepted'])
+                    ->rules(fn (Get $get): array => filled($get('url')) ? ['accepted'] : [])
                     ->dehydrated(false),
             ]);
     }

--- a/app/Filament/Resources/TeamResource.php
+++ b/app/Filament/Resources/TeamResource.php
@@ -17,6 +17,7 @@ use Filament\Forms\Components\FileUpload;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Resources\Resource;
+use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Schema;
 use Filament\Tables\Columns\CheckboxColumn;
 use Filament\Tables\Columns\TextColumn;
@@ -43,7 +44,7 @@ class TeamResource extends Resource
                     ->avatar(),
                 Checkbox::make('dmca_certification')
                     ->label('I certify that I own this image or have a legitimate license/permission to share it. I understand that Knuckleball follows a strict DMCA policy and will remove infringing content and terminate repeat infringer accounts.')
-                    ->rules(['accepted'])
+                    ->rules(fn (Get $get): array => filled($get('url')) ? ['accepted'] : [])
                     ->dehydrated(false),
             ]);
     }

--- a/app/Livewire/ViewPlayers.php
+++ b/app/Livewire/ViewPlayers.php
@@ -16,6 +16,7 @@ use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Concerns\InteractsWithForms;
 use Filament\Forms\Contracts\HasForms;
+use Filament\Schemas\Components\Utilities\Get;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Concerns\InteractsWithTable;
 use Filament\Tables\Contracts\HasTable;
@@ -133,7 +134,7 @@ class ViewPlayers extends Component implements HasActions, HasForms, HasTable
                     ->avatar(),
                 Checkbox::make('dmca_certification')
                     ->label('I certify that I own this image or have a legitimate license/permission to share it. I understand that Knuckleball follows a strict DMCA policy and will remove infringing content and terminate repeat infringer accounts.')
-                    ->rules(['accepted'])
+                    ->rules(fn (Get $get): array => filled($get('url')) ? ['accepted'] : [])
                     ->dehydrated(false),
             ])
             ->using(function (array $data): Model {

--- a/tests/Feature/Filament/Resources/PlayerResourceTest.php
+++ b/tests/Feature/Filament/Resources/PlayerResourceTest.php
@@ -4,6 +4,8 @@ use App\Filament\Resources\PlayerResource;
 use App\Models\Player;
 use App\Models\Team;
 use App\Models\User;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
 use Livewire\Livewire;
 
 use function Pest\Laravel\assertDatabaseHas;
@@ -243,4 +245,32 @@ it('can associate player with user', function () {
         'name' => 'Test Player',
         'user_id' => $user->id,
     ]);
+});
+
+it('does not require dmca certification when no image is uploaded', function () {
+    $team = Team::factory()->create();
+
+    Livewire::test(PlayerResource\Pages\CreatePlayer::class)
+        ->fillForm([
+            'name' => 'Test Player',
+            'team_id' => $team->id,
+            'dmca_certification' => false,
+        ])
+        ->call('create')
+        ->assertHasNoFormErrors();
+});
+
+it('requires dmca certification when an image is uploaded', function () {
+    Storage::fake('public');
+    $team = Team::factory()->create();
+
+    Livewire::test(PlayerResource\Pages\CreatePlayer::class)
+        ->fillForm([
+            'name' => 'Test Player',
+            'team_id' => $team->id,
+            'url' => UploadedFile::fake()->image('avatar.jpg'),
+            'dmca_certification' => false,
+        ])
+        ->call('create')
+        ->assertHasFormErrors(['dmca_certification' => 'accepted']);
 });


### PR DESCRIPTION
## Summary

- The DMCA certification checkbox was always required, even when no image was being uploaded
- Changed `->rules(['accepted'])` to a closure using `Get` so the rule only fires when the `url` field has a value
- Affects `PlayerResource`, `TeamResource`, and the `ViewPlayers` New Player modal

## Test plan

- [ ] Verify you can save a player/team without an image and without checking the DMCA box
- [ ] Verify that uploading an image still requires the DMCA box to be checked before saving

🤖 Generated with [Claude Code](https://claude.com/claude-code)