### PR TITLE
Fix trending GROUP BY error and update landing nav for auth state

### DIFF
--- a/app/Livewire/TrendingFeed.php
+++ b/app/Livewire/TrendingFeed.php
@@ -66,8 +66,8 @@ class TrendingFeed extends Component
     #[Computed]
     public function trendingPlayers()
     {
-        return Player::query()
-            ->select('players.*')
+        $subquery = Player::query()
+            ->selectRaw('players.id, COUNT(postal_mails.id) as send_count')
             ->join('signers', fn ($j) => $j
                 ->on('signers.signable_id', '=', 'players.id')
                 ->where('signers.signable_type', Player::class)
@@ -77,11 +77,15 @@ class TrendingFeed extends Component
                 ->whereNotNull('postal_mails.date_sent')
                 ->where('postal_mails.created_at', '>=', now()->subDays(30))
             )
-            ->selectRaw('COUNT(postal_mails.id) as send_count')
-            ->with('media', 'team.category')
             ->groupBy('players.id')
             ->orderByDesc('send_count')
-            ->limit(10)
+            ->limit(10);
+
+        return Player::query()
+            ->joinSub($subquery, 'counts', fn ($j) => $j->on('players.id', '=', 'counts.id'))
+            ->select('players.*', 'counts.send_count')
+            ->with('media', 'team.category')
+            ->orderByDesc('counts.send_count')
             ->get();
     }
 

--- a/resources/views/landing.blade.php
+++ b/resources/views/landing.blade.php
@@ -60,11 +60,17 @@
                 <a href="{{ route('players.index') }}" class="hover:text-red-200 transition-colors">TTM DATABASE</a>
                 <a href="#contact" class="hover:text-red-200 transition-colors">CONTACT</a>
             </div>
-            <div class="flex items-center gap-4">
-                <a href="{{ route('login') }}" class="text-sm font-semibold hover:text-red-200 transition-colors hidden sm:block">Log In</a>
-                <a href="{{ route('register') }}" class="bg-white text-[#CB504B] hover:bg-gray-50 text-sm font-bold px-5 py-2.5 rounded-full transition-colors shadow-sm">
-                    Join Free
-                </a>
+            <div class="flex items-center gap-3">
+                @auth
+                    <a href="{{ route('players.index') }}" class="bg-white text-[#CB504B] hover:bg-gray-50 text-sm font-bold px-5 py-2.5 rounded-full transition-colors shadow-sm">
+                        TTM Database
+                    </a>
+                @else
+                    <a href="{{ route('login') }}" class="text-sm font-semibold hover:text-red-200 transition-colors border border-white/40 px-4 py-2 rounded-full sm:border-0 sm:px-0 sm:py-0">Log In</a>
+                    <a href="{{ route('register') }}" class="bg-white text-[#CB504B] hover:bg-gray-50 text-sm font-bold px-5 py-2.5 rounded-full transition-colors shadow-sm">
+                        Join Free
+                    </a>
+                @endauth
             </div>
         </div>
     </nav>
@@ -152,13 +158,13 @@
                 @if ($item['isReturn'])
                     <span>
                         <span class="text-orange-400">🔥</span>
-                        <span class="font-bold">Mail day for @{{ $item['slug'] }}:</span>
+                        <span class="font-bold">Mail day for {{ '@' . $item['slug'] }}:</span>
                         {{ $item['player'] }}{{ $item['days'] ? ' (' . $item['days'] . ' Days)' : '' }}
                     </span>
                 @else
                     <span>
                         <span class="text-green-400">📬</span>
-                        <span class="font-bold">@{{ $item['slug'] }} sent:</span>
+                        <span class="font-bold">{{ '@' . $item['slug'] }} sent:</span>
                         {{ $item['player'] }}
                     </span>
                 @endif
@@ -174,13 +180,13 @@
                 @if ($item['isReturn'])
                     <span>
                         <span class="text-orange-400">🔥</span>
-                        <span class="font-bold">Mail day for @{{ $item['slug'] }}:</span>
+                        <span class="font-bold">Mail day for {{ '@' . $item['slug'] }}:</span>
                         {{ $item['player'] }}{{ $item['days'] ? ' (' . $item['days'] . ' Days)' : '' }}
                     </span>
                 @else
                     <span>
                         <span class="text-green-400">📬</span>
-                        <span class="font-bold">@{{ $item['slug'] }} sent:</span>
+                        <span class="font-bold">{{ '@' . $item['slug'] }} sent:</span>
                         {{ $item['player'] }}
                     </span>
                 @endif

--- a/tests/Feature/HomeTest.php
+++ b/tests/Feature/HomeTest.php
@@ -1,0 +1,22 @@
+<?php
+
+use App\Models\User;
+
+it('shows log in and join free links for guests', function () {
+    $this->get(route('home'))
+        ->assertStatus(200)
+        ->assertSee('Log In')
+        ->assertSee('Join Free')
+        ->assertDontSee('TTM Database');
+});
+
+it('shows ttm database link instead of login buttons when authenticated', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->get(route('home'))
+        ->assertStatus(200)
+        ->assertSee('TTM Database')
+        ->assertDontSee('Join Free')
+        ->assertDontSee('Log In');
+});

--- a/tests/Feature/Livewire/TrendingFeedTest.php
+++ b/tests/Feature/Livewire/TrendingFeedTest.php
@@ -1,0 +1,56 @@
+<?php
+
+use App\Livewire\TrendingFeed;
+use App\Models\Player;
+use App\Models\PostalMail;
+use App\Models\Signer;
+use App\Models\User;
+use Livewire\Livewire;
+
+it('renders without a GROUP BY error', function () {
+    $player = Player::factory()->create();
+    $signer = Signer::factory()->create([
+        'signable_id' => $player->id,
+        'signable_type' => Player::class,
+    ]);
+    PostalMail::factory()->count(3)->create([
+        'signer_id' => $signer->id,
+        'date_sent' => now()->subWeek(),
+        'created_at' => now()->subDays(10),
+    ]);
+
+    Livewire::actingAs(User::factory()->create())
+        ->test(TrendingFeed::class)
+        ->assertStatus(200);
+});
+
+it('shows the trending players ranked by send count', function () {
+    $topPlayer = Player::factory()->create();
+    $topSigner = Signer::factory()->create([
+        'signable_id' => $topPlayer->id,
+        'signable_type' => Player::class,
+    ]);
+    PostalMail::factory()->count(5)->create([
+        'signer_id' => $topSigner->id,
+        'date_sent' => now()->subWeek(),
+        'created_at' => now()->subDays(10),
+    ]);
+
+    $otherPlayer = Player::factory()->create();
+    $otherSigner = Signer::factory()->create([
+        'signable_id' => $otherPlayer->id,
+        'signable_type' => Player::class,
+    ]);
+    PostalMail::factory()->count(2)->create([
+        'signer_id' => $otherSigner->id,
+        'date_sent' => now()->subWeek(),
+        'created_at' => now()->subDays(10),
+    ]);
+
+    $component = Livewire::actingAs(User::factory()->create())
+        ->test(TrendingFeed::class);
+
+    $players = $component->get('trendingPlayers');
+    expect($players->first()->id)->toBe($topPlayer->id)
+        ->and((int) $players->first()->send_count)->toBe(5);
+});


### PR DESCRIPTION
## Summary

- **Trending page fix**: Restructured `trendingPlayers()` to aggregate in a subquery (grouped by `players.id` only), then `joinSub()` to fetch full player data — eliminates the `ONLY_FULL_GROUP_BY` SQL error
- **Landing navbar**: Logged-in users see a "TTM Database" button instead of "Log In / Join Free"; guest "Log In" is now visible on mobile (styled as a ghost pill, border drops on `sm:` and up)
- Added `HomeTest` and `TrendingFeedTest` covering both changes

## Test plan

- [ ] Visit the landing page as a guest — confirm "Log In" and "Join Free" are both visible on mobile and desktop
- [ ] Visit the landing page while logged in — confirm only "TTM Database" appears, clicking it goes to the players index
- [ ] Visit the Trending page — confirm it loads without a SQL error and players rank by send count

🤖 Generated with [Claude Code](https://claude.com/claude-code)