### PR TITLE
Fix images and state field for UK/AU/EU support

### DIFF
--- a/app/Livewire/SubmitCardShop.php
+++ b/app/Livewire/SubmitCardShop.php
@@ -89,8 +89,8 @@ class SubmitCardShop extends Component
         }
 
         $filteredHours = collect($this->hours)->filter(fn ($h) => ! empty($h['open']))->toArray();
-        $logoPath = $this->logo ? $this->logo->store('shops/logos', 'public') : null;
-        $storePhotoPath = $this->storePhoto ? $this->storePhoto->store('shops/photos', 'public') : null;
+        $logoPath = $this->logo ? $this->logo->storePublicly('shops/logos') : null;
+        $storePhotoPath = $this->storePhoto ? $this->storePhoto->storePublicly('shops/photos') : null;
 
         $shop = CardShop::create([
             'name' => $this->name,

--- a/app/Livewire/SubmitEvent.php
+++ b/app/Livewire/SubmitEvent.php
@@ -272,7 +272,7 @@ class SubmitEvent extends Component
         }
 
         if ($this->heroImage) {
-            $data['photos'] = [$this->heroImage->store('events', 'public')];
+            $data['photos'] = [$this->heroImage->storePublicly('events')];
         }
 
         $addScheme = fn (?string $url): ?string => $url && ! preg_match('#^https?://#i', $url) ? 'https://' . $url : $url;

--- a/database/migrations/2026_05_26_102418_expand_state_column_length_on_events_and_card_shops.php
+++ b/database/migrations/2026_05_26_102418_expand_state_column_length_on_events_and_card_shops.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('events', function (Blueprint $table): void {
+            $table->string('state', 3)->nullable()->change();
+        });
+
+        Schema::table('card_shops', function (Blueprint $table): void {
+            $table->string('state', 3)->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('events', function (Blueprint $table): void {
+            $table->string('state', 2)->nullable()->change();
+        });
+
+        Schema::table('card_shops', function (Blueprint $table): void {
+            $table->string('state', 2)->change();
+        });
+    }
+};


### PR DESCRIPTION
## Summary

- Expand `state` column from `varchar(2)` to `varchar(3)` on `events` and `card_shops` tables to support UK, Australian, and European region codes (e.g. `WLS`, `NSW`, `VIC`) added in the States helper
- Fix `SubmitEvent` and `SubmitCardShop` Livewire components to store uploaded files on the default disk instead of hardcoded `'public'` disk, ensuring S3 compatibility

## Test plan

- [ ] Run migrations: `php artisan migrate`
- [ ] Submit an event with a UK/AU/EU state — confirm it saves without truncation
- [ ] Submit an event with an image — confirm the image URL resolves correctly on S3
- [ ] Submit a card shop with logo/photo — confirm images resolve correctly on S3
- [ ] Run `php artisan test --compact`

🤖 Generated with [Claude Code](https://claude.com/claude-code)