### PR TITLE
Fix production errors: S3 download fpassthru and missing player name validation

### DIFF
--- a/app/Http/Controllers/ReturnCardController.php
+++ b/app/Http/Controllers/ReturnCardController.php
@@ -5,9 +5,9 @@ namespace App\Http\Controllers;
 use App\Models\PostalMail;
 use App\Services\ReturnCardService;
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\URL;
-use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class ReturnCardController extends Controller
 {
@@ -28,7 +28,7 @@ class ReturnCardController extends Controller
      * Serve the generated image as a download.
      * Route is protected by a signed URL (no auth required, expires 24h).
      */
-    public function download(Request $request, PostalMail $mail, string $format): StreamedResponse
+    public function download(Request $request, PostalMail $mail, string $format): Response
     {
         abort_unless(in_array($format, ['square', 'story']), 404);
         abort_unless($request->hasValidSignature(), 403);
@@ -42,6 +42,9 @@ class ReturnCardController extends Controller
         $slug = str($player?->name ?? 'return')->slug('-');
         $filename = "knuckleball-{$slug}-{$format}.jpg";
 
-        return Storage::download($path, $filename, ['Content-Type' => 'image/jpeg']);
+        return response(Storage::get($path), 200, [
+            'Content-Type' => 'image/jpeg',
+            'Content-Disposition' => 'attachment; filename="' . $filename . '"',
+        ]);
     }
 }

--- a/app/Livewire/ViewPlayers.php
+++ b/app/Livewire/ViewPlayers.php
@@ -71,7 +71,7 @@ class ViewPlayers extends Component implements HasActions, HasForms, HasTable
             ->recordActions([
                 EditAction::make()
                     ->schema([
-                        TextInput::make('name'),
+                        TextInput::make('name')->required(),
                         Select::make('team_id')
                             ->label('Team')
                             ->options(fn () => Team::get()->pluck('name', 'id')->toArray())
@@ -107,7 +107,7 @@ class ViewPlayers extends Component implements HasActions, HasForms, HasTable
             ->model(Player::class)
             ->label(__('New Player'))
             ->schema([
-                TextInput::make('name'),
+                TextInput::make('name')->required(),
                 Select::make('team_id')
                     ->label('Team')
                     ->relationship('team')
@@ -120,7 +120,7 @@ class ViewPlayers extends Component implements HasActions, HasForms, HasTable
                     ->createOptionModalHeading('Create Team')
                     ->createOptionForm(function () {
                         return [
-                            TextInput::make('name'),
+                            TextInput::make('name')->required(),
                         ];
                     })
                     ->createOptionUsing(function (array $data) {

--- a/tests/Feature/Http/Controllers/ReturnCardControllerTest.php
+++ b/tests/Feature/Http/Controllers/ReturnCardControllerTest.php
@@ -1,0 +1,61 @@
+<?php
+
+use App\Http\Controllers\ReturnCardController;
+use App\Models\PostalMail;
+use App\Services\ReturnCardService;
+use Illuminate\Support\Facades\Storage;
+
+use function Pest\Laravel\get;
+
+beforeEach(function () {
+    Storage::fake();
+});
+
+it('serves a jpeg download via a valid signed url', function (string $format) {
+    $mail = PostalMail::factory()->returned()->create();
+
+    $service = $this->mock(ReturnCardService::class);
+    $service->shouldReceive('getOrGenerate')
+        ->once()
+        ->with(Mockery::on(fn ($m) => $m->id === $mail->id), $format)
+        ->andReturnUsing(function () use ($mail, $format) {
+            $path = "return-cards/{$mail->id}/{$format}.jpg";
+            Storage::put($path, 'fake-image-bytes');
+
+            return $path;
+        });
+
+    $url = ReturnCardController::signedUrl($mail, $format);
+
+    get($url)
+        ->assertSuccessful()
+        ->assertHeader('Content-Type', 'image/jpeg')
+        ->assertDownload();
+})->with(['square', 'story']);
+
+it('returns 403 for an invalid signature', function () {
+    $mail = PostalMail::factory()->returned()->create();
+
+    get(route('returns.card.download', ['mail' => $mail->id, 'format' => 'square']))
+        ->assertForbidden();
+});
+
+it('returns 404 for an unknown format', function () {
+    $mail = PostalMail::factory()->returned()->create();
+
+    $url = ReturnCardController::signedUrl($mail, 'square');
+    $url = str_replace('/square?', '/invalid?', $url);
+
+    get($url)->assertNotFound();
+});
+
+it('returns 404 when the generated file does not exist on storage', function () {
+    $mail = PostalMail::factory()->returned()->create();
+
+    $service = $this->mock(ReturnCardService::class);
+    $service->shouldReceive('getOrGenerate')->once()->andReturn('return-cards/1/square.jpg');
+
+    $url = ReturnCardController::signedUrl($mail, 'square');
+
+    get($url)->assertNotFound();
+});

--- a/tests/Feature/Livewire/ViewPlayersTest.php
+++ b/tests/Feature/Livewire/ViewPlayersTest.php
@@ -70,3 +70,22 @@ test('Players cannot be updated by non-users', function () {
     $player = Player::factory()->published()->create();
     Livewire::test('ViewPlayers')->assertActionHidden(TestAction::make('edit')->table($player));
 });
+
+test('Creating a player requires a name', function () {
+    $user = User::factory()->isSuperAdmin()->create();
+
+    Livewire::actingAs($user)
+        ->test(ViewPlayers::class)
+        ->callAction('create', ['name' => null, 'team_id' => null])
+        ->assertHasActionErrors(['name' => 'required']);
+});
+
+test('Editing a player requires a name', function () {
+    $user = User::factory()->isSuperAdmin()->create();
+    $player = Player::factory()->published()->create();
+
+    Livewire::actingAs($user)
+        ->test(ViewPlayers::class)
+        ->callAction(TestAction::make('edit')->table($player), ['name' => null])
+        ->assertHasActionErrors(['name' => 'required']);
+});


### PR DESCRIPTION
## Summary

- **Fix `fpassthru` error on S3 downloads** (`ReturnCardController`): `Storage::download()` calls `fpassthru()` inside the `Illuminate\Filesystem` namespace without a leading backslash, causing a namespace resolution failure on the Cloudways/S3 stack. Replaced with `response(Storage::get($path), 200, [...])` to bypass Flysystem's streaming path entirely.
- **Add required validation to player name** (`ViewPlayers`): `name` is `NOT NULL` in the DB but all three form contexts (create action, edit action, inline team create) had no `->required()` rule, allowing null submissions to reach the DB and throw a `QueryException`.

## Test plan

- [ ] `php artisan test --compact tests/Feature/Http/Controllers/ReturnCardControllerTest.php` — 5 tests covering download happy path (square + story), invalid signature (403), unknown format (404), missing file (404)
- [ ] `php artisan test --compact tests/Feature/Livewire/ViewPlayersTest.php` — 8 tests including new validation tests for create and edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)