### PR TITLE
Fix return card images rendering black

### DIFF
--- a/app/Livewire/ShowReturn.php
+++ b/app/Livewire/ShowReturn.php
@@ -20,9 +20,14 @@ class ShowReturn extends Component
 
         $this->mail = $mail;
 
-        // Pre-generate cards so the OG image is ready immediately for crawlers
-        app(ReturnCardService::class)->getOrGenerate($mail, 'square');
-        app(ReturnCardService::class)->getOrGenerate($mail, 'story');
+        $service = app(ReturnCardService::class);
+
+        if (request()->boolean('refresh')) {
+            $service->generate($mail);
+        } else {
+            $service->getOrGenerate($mail, 'square');
+            $service->getOrGenerate($mail, 'story');
+        }
     }
 
     public function openShare(): void

--- a/app/Services/ReturnCardService.php
+++ b/app/Services/ReturnCardService.php
@@ -126,7 +126,7 @@ class ReturnCardService
         }
 
         if (Storage::exists($url)) {
-            return Storage::url($url);
+            return $url;
         }
 
         return null;
@@ -143,7 +143,7 @@ class ReturnCardService
         $heroPath = $d['cardPhotoPath'] ?? $d['playerPhotoPath'];
         if ($heroPath) {
             try {
-                $hero = $this->manager->read($heroPath)->cover(1080, 540);
+                $hero = $this->manager->read(Storage::get($heroPath))->cover(1080, 540);
                 $canvas->place($hero, 'top-left', 0, 0);
                 // Bottom fade overlay
                 $fade = $this->manager->create(1080, 300)->fill(self::BG);
@@ -193,7 +193,7 @@ class ReturnCardService
         $heroPath = $d['cardPhotoPath'] ?? $d['playerPhotoPath'];
         if ($heroPath) {
             try {
-                $hero = $this->manager->read($heroPath)->cover(1080, 1000);
+                $hero = $this->manager->read(Storage::get($heroPath))->cover(1080, 1000);
                 $canvas->place($hero, 'top-left', 0, 0);
                 $fade = $this->manager->create(1080, 500)->fill(self::BG);
                 $canvas->place($fade, 'top-left', 0, 500, 75);


### PR DESCRIPTION
## Summary

- `ReturnCardService::resolveStoragePath()` was returning `Storage::url()` (a relative web path like `/storage/...`) which Intervention Image cannot read as a filesystem path, causing the hero image to be skipped and cards to render with a black background
- Fixed by returning the raw storage key and reading binary contents via `Storage::get()`, which works on both local and S3 disks
- Adds `?refresh=true` query param to `/returns/{mail}` to force-regenerate cached cards (useful for fixing already-cached black images)

## Test plan

- [ ] Visit a return page — hero image should now appear on the card
- [ ] Visit `/returns/{mail}?refresh=true` to force-regenerate any previously cached black cards
- [ ] Confirm square and story downloads include the image

🤖 Generated with [Claude Code](https://claude.com/claude-code)