### PR TITLE
Fix banded lines on return card gradient

### DIFF
--- a/app/Services/ReturnCardService.php
+++ b/app/Services/ReturnCardService.php
@@ -246,10 +246,12 @@ class ReturnCardService
             imageline($gd, 0, $y, 1079, $y, $color);
         }
 
-        ob_start();
-        imagepng($gd);
-        $png = ob_get_clean();
+        $stream = fopen('php://memory', 'r+');
+        imagepng($gd, $stream);
         imagedestroy($gd);
+        rewind($stream);
+        $png = stream_get_contents($stream);
+        fclose($stream);
 
         $canvas->place($this->manager->read($png), 'top-left', 0, $startY);
     }

--- a/app/Services/ReturnCardService.php
+++ b/app/Services/ReturnCardService.php
@@ -230,18 +230,28 @@ class ReturnCardService
 
     // ── Shared helpers ────────────────────────────────────────────
 
-    private function drawGradientFade($canvas, int $startY, int $endY, int $steps = 24): void
+    private function drawGradientFade($canvas, int $startY, int $endY): void
     {
         [$red, $green, $blue] = sscanf(ltrim(self::BG, '#'), '%02x%02x%02x');
-        $stepHeight = (int) ceil(($endY - $startY) / $steps);
+        $height = $endY - $startY;
 
-        for ($i = 0; $i < $steps; $i++) {
-            $alpha = round($i / max(1, $steps - 1), 4);
-            $y = $startY + ($i * $stepHeight);
-            $color = "rgba({$red}, {$green}, {$blue}, {$alpha})";
-            $canvas->drawRectangle(0, $y, fn (RectangleFactory $rect) => $rect->size(1080, $stepHeight + 1)->background($color)
-            );
+        $gd = imagecreatetruecolor(1080, $height);
+        imagealphablending($gd, false);
+        imagesavealpha($gd, true);
+
+        for ($y = 0; $y < $height; $y++) {
+            // GD alpha: 0 = fully opaque, 127 = fully transparent
+            $gdAlpha = (int) round(127 * (1 - $y / max(1, $height - 1)));
+            $color = imagecolorallocatealpha($gd, $red, $green, $blue, $gdAlpha);
+            imageline($gd, 0, $y, 1079, $y, $color);
         }
+
+        ob_start();
+        imagepng($gd);
+        $png = ob_get_clean();
+        imagedestroy($gd);
+
+        $canvas->place($this->manager->read($png), 'top-left', 0, $startY);
     }
 
     /**


### PR DESCRIPTION
## Summary

- Replaced the step-based gradient (24 rectangles with fixed opacity) with a true per-pixel gradient built via GD — this eliminates the visible horizontal lines between steps
- Uses a `php://memory` stream instead of `ob_start()`/`ob_get_clean()` to write the PNG, avoiding potential output buffering issues on Cloudways

## Test plan

- [ ] Merge and use `?refresh=true` on a return with a photo — the fade from the hero image into the dark background should be smooth with no visible banding

🤖 Generated with [Claude Code](https://claude.com/claude-code)