### PR TITLE
Sliding window infinite scroll with bidirectional loading

### DIFF
--- a/app/Livewire/UserFeed.php
+++ b/app/Livewire/UserFeed.php
@@ -11,8 +11,12 @@ use Livewire\Component;
 class UserFeed extends Component
 {
     public int $perPage = 15;
+    public int $offset = 0;
     public bool $hasMore = true;
+    public bool $hasPrevious = false;
     public string $filter = 'global'; // 'following' | 'global'
+
+    private int $maxWindow = 45;
 
     public function render()
     {
@@ -34,10 +38,12 @@ class UserFeed extends Component
             ->withCount('feedComments')
             ->with(['reactions', 'feedable'])
             ->orderByDesc('created_at')
+            ->skip($this->offset)
             ->limit($this->perPage + 1);
 
         $results = $query->get();
         $this->hasMore = $results->count() > $this->perPage;
+        $this->hasPrevious = $this->offset > 0;
 
         return $results->take($this->perPage);
     }
@@ -66,7 +72,17 @@ class UserFeed extends Component
 
     public function loadMore(): void
     {
-        $this->perPage += 15;
+        if ($this->perPage < $this->maxWindow) {
+            $this->perPage += 15;
+        } else {
+            $this->offset += 15;
+        }
+        unset($this->feeds);
+    }
+
+    public function loadPrevious(): void
+    {
+        $this->offset = max(0, $this->offset - 15);
         unset($this->feeds);
     }
 
@@ -74,12 +90,15 @@ class UserFeed extends Component
     {
         $this->filter = $filter;
         $this->perPage = 15;
+        $this->offset = 0;
         unset($this->feeds);
     }
 
     #[On('feed-updated')]
     public function updateFeed(): void
     {
+        $this->perPage = 15;
+        $this->offset = 0;
         unset($this->feeds, $this->trendingStrip);
     }
 }

--- a/resources/views/livewire/user-feed.blade.php
+++ b/resources/views/livewire/user-feed.blade.php
@@ -113,10 +113,32 @@
                     @endauth
                 </div>
 
+                {{-- Load previous sentinel --}}
+                @if ($hasPrevious)
+                    <div
+                        wire:key="top-sentinel-{{ $offset }}"
+                        x-data
+                        x-init="
+                            const obs = new IntersectionObserver((entries) => {
+                                if (entries[0].isIntersecting) {
+                                    obs.disconnect();
+                                    $wire.loadPrevious();
+                                }
+                            }, { rootMargin: '200px' });
+                            obs.observe($el);
+                        "
+                        class="flex justify-center py-6"
+                    >
+                        <div class="size-5 rounded-full border-2 border-[#D93C3F] border-t-transparent animate-spin opacity-60"></div>
+                    </div>
+                @endif
+
                 {{-- Feed items --}}
                 <div class="space-y-2">
                     @forelse ($this->feeds as $feed)
-                        <x-dynamic-component :component="$feed->componentName()" :$feed />
+                        <div wire:key="feed-{{ $feed->id }}">
+                            <x-dynamic-component :component="$feed->componentName()" :$feed />
+                        </div>
                     @empty
                         <div class="text-center py-12 text-gray-400">
                             <x-heroicon-o-inbox class="size-10 mx-auto mb-3 opacity-40" />
@@ -125,9 +147,10 @@
                     @endforelse
                 </div>
 
-                {{-- Infinite scroll sentinel --}}
+                {{-- Load more sentinel --}}
                 @if ($hasMore)
                     <div
+                        wire:key="bottom-sentinel-{{ $offset }}-{{ $perPage }}"
                         x-data
                         x-init="
                             const obs = new IntersectionObserver((entries) => {

--- a/tests/Feature/Livewire/UserFeedTest.php
+++ b/tests/Feature/Livewire/UserFeedTest.php
@@ -42,3 +42,74 @@ test('it pulls the feeds', function () {
         ->instance()
         ->feeds);
 });
+
+test('loadMore grows the window until maxWindow then slides the offset', function () {
+    Feed::factory(60)->postalMail()->create();
+
+    $component = Livewire::test(UserFeed::class);
+    expect($component->instance()->feeds)->toHaveCount(15);
+    expect($component->get('offset'))->toBe(0);
+    expect($component->get('hasPrevious'))->toBeFalse();
+
+    $component->call('loadMore');
+    expect($component->instance()->feeds)->toHaveCount(30);
+    expect($component->get('offset'))->toBe(0);
+
+    $component->call('loadMore');
+    expect($component->instance()->feeds)->toHaveCount(45);
+    expect($component->get('offset'))->toBe(0);
+
+    // Window is now full — next loadMore slides instead of growing
+    $component->call('loadMore');
+    expect($component->instance()->feeds)->toHaveCount(45);
+    expect($component->get('offset'))->toBe(15);
+    expect($component->get('hasPrevious'))->toBeTrue();
+});
+
+test('loadPrevious decrements the offset and clamps at zero', function () {
+    Feed::factory(60)->postalMail()->create();
+
+    $component = Livewire::test(UserFeed::class);
+
+    // Slide the window forward twice
+    $component->call('loadMore'); // perPage 30
+    $component->call('loadMore'); // perPage 45
+    $component->call('loadMore'); // offset 15
+    $component->call('loadMore'); // offset 30
+
+    expect($component->get('offset'))->toBe(30);
+
+    $component->call('loadPrevious');
+    expect($component->get('offset'))->toBe(15);
+    expect($component->get('hasPrevious'))->toBeTrue();
+
+    $component->call('loadPrevious');
+    expect($component->get('offset'))->toBe(0);
+    expect($component->get('hasPrevious'))->toBeFalse();
+
+    // Clamped — does not go negative
+    $component->call('loadPrevious');
+    expect($component->get('offset'))->toBe(0);
+});
+
+test('hasMore is false when all feeds are loaded', function () {
+    Feed::factory(10)->postalMail()->create();
+
+    $component = Livewire::test(UserFeed::class);
+
+    expect($component->get('hasMore'))->toBeFalse();
+});
+
+test('setFilter resets offset and perPage', function () {
+    Feed::factory(60)->postalMail()->create();
+
+    $component = Livewire::test(UserFeed::class);
+    $component->call('loadMore');
+    $component->call('loadMore');
+    $component->call('loadMore'); // offset now 15
+
+    $component->call('setFilter', 'following');
+
+    expect($component->get('offset'))->toBe(0);
+    expect($component->get('perPage'))->toBe(15);
+});


### PR DESCRIPTION
## Summary

- Caps the feed DOM at 45 items (3 pages) to prevent unbounded Livewire component growth
- Once the window is full, `loadMore` slides the offset forward instead of growing the list — removing a page from the top as one is added at the bottom
- Adds a top sentinel that triggers `loadPrevious` when scrolled into view, letting users scroll back to earlier items
- Scroll position preservation in both directions is handled by the browser's native CSS scroll anchoring — no custom JS needed
- Added `wire:key` to feed item wrappers so Livewire's morph algorithm correctly identifies survivors during window slides

## Test plan

- [ ] Scroll down through 3+ pages and confirm the feed stays at 45 items
- [ ] Continue scrolling down and confirm older items load at the bottom while the top trims
- [ ] Scroll back up to the top sentinel and confirm earlier items reload
- [ ] Confirm scroll position doesn't jump when loading in either direction
- [ ] Switch between Following/Global filters and confirm the window resets
- [ ] All 7 `UserFeedTest` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)