### PR TITLE
Replace scroll sentinels with buttons in sliding window mode

### DIFF
--- a/app/Livewire/UserFeed.php
+++ b/app/Livewire/UserFeed.php
@@ -16,7 +16,7 @@ class UserFeed extends Component
     public bool $hasPrevious = false;
     public string $filter = 'global'; // 'following' | 'global'
 
-    private int $maxWindow = 45;
+    public int $maxWindow = 45;
 
     public function render()
     {

--- a/resources/views/livewire/user-feed.blade.php
+++ b/resources/views/livewire/user-feed.blade.php
@@ -113,25 +113,12 @@
                     @endauth
                 </div>
 
-                {{-- Load previous sentinel --}}
+                {{-- Load previous button --}}
                 @if ($hasPrevious)
-                    <div
-                        wire:key="top-sentinel-{{ $offset }}"
-                        x-data
-                        x-init="
-                            requestAnimationFrame(() => {
-                                const obs = new IntersectionObserver((entries) => {
-                                    if (entries[0].isIntersecting) {
-                                        obs.disconnect();
-                                        $wire.loadPrevious();
-                                    }
-                                }, { rootMargin: '200px' });
-                                obs.observe($el);
-                            });
-                        "
-                        class="flex justify-center py-6"
-                    >
-                        <div class="size-5 rounded-full border-2 border-[#D93C3F] border-t-transparent animate-spin opacity-60"></div>
+                    <div class="flex justify-center py-2">
+                        <button wire:click="loadPrevious" class="text-sm font-medium text-[#D93C3F] hover:text-[#b82e31] transition-colors">
+                            &uarr; Load previous
+                        </button>
                     </div>
                 @endif
 
@@ -149,26 +136,33 @@
                     @endforelse
                 </div>
 
-                {{-- Load more sentinel --}}
+                {{-- Load more: auto-sentinel while window is growing, button once sliding --}}
                 @if ($hasMore)
-                    <div
-                        wire:key="bottom-sentinel-{{ $offset }}-{{ $perPage }}"
-                        x-data
-                        x-init="
-                            requestAnimationFrame(() => {
-                                const obs = new IntersectionObserver((entries) => {
-                                    if (entries[0].isIntersecting) {
+                    @if ($perPage < $maxWindow)
+                        <div
+                            wire:key="bottom-sentinel-{{ $offset }}-{{ $perPage }}"
+                            x-data
+                            x-init="
+                                requestAnimationFrame(() => {
+                                    const obs = new IntersectionObserver((entries) => {
+                                        if (!entries[0].isIntersecting) return;
                                         obs.disconnect();
                                         $wire.loadMore();
-                                    }
-                                }, { rootMargin: '200px' });
-                                obs.observe($el);
-                            });
-                        "
-                        class="flex justify-center py-6"
-                    >
-                        <div class="size-5 rounded-full border-2 border-[#D93C3F] border-t-transparent animate-spin opacity-60"></div>
-                    </div>
+                                    }, { rootMargin: '200px' });
+                                    obs.observe($el);
+                                });
+                            "
+                            class="flex justify-center py-6"
+                        >
+                            <div class="size-5 rounded-full border-2 border-[#D93C3F] border-t-transparent animate-spin opacity-60"></div>
+                        </div>
+                    @else
+                        <div class="flex justify-center py-2">
+                            <button wire:click="loadMore" class="text-sm font-medium text-[#D93C3F] hover:text-[#b82e31] transition-colors">
+                                Load more &darr;
+                            </button>
+                        </div>
+                    @endif
                 @else
                     <p class="text-center text-gray-400 text-sm py-8">You're all caught up.</p>
                 @endif


### PR DESCRIPTION
## Summary

- Fixes the infinite scroll loop that occurred when the window started sliding
- Auto-loading sentinel still works for the first three pages (window growing, no sliding, no scroll issues)
- Once the window is full (45 items) and sliding kicks in, both ends become explicit **Load more ↓** / **↑ Load previous** buttons

## Why buttons

The `IntersectionObserver` approach fought against scroll position shifting during a slide — newly inserted items haven't loaded their images yet, so they start with very little height. The bottom sentinel lands within the `200px` rootMargin immediately, fires, and loops. A button only fires on an explicit click, so timing is irrelevant.

## Test plan

- [ ] Scroll through first 45 items — auto-loading sentinel works as before
- [ ] At 45 items the sentinel is replaced by a **Load more** button; clicking loads the next page and trims the top
- [ ] A **Load previous** button appears at the top; clicking it restores the previous page
- [ ] No looping or unexpected loads
- [ ] All 7 `UserFeedTest` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)