### PR TITLE
Apply sliding window infinite scroll to TrendingFeed

### DIFF
--- a/app/Livewire/TrendingFeed.php
+++ b/app/Livewire/TrendingFeed.php
@@ -11,7 +11,10 @@ use Livewire\Component;
 class TrendingFeed extends Component
 {
     public int $perPage = 20;
+    public int $offset = 0;
     public bool $hasMore = true;
+    public bool $hasPrevious = false;
+    public int $maxWindow = 60;
     public string $sort = 'reactions'; // 'reactions' | 'fastest' | 'comments'
 
     public function render()
@@ -40,7 +43,7 @@ class TrendingFeed extends Component
 
         // For 'fastest' we sort in PHP to avoid cross-DB JSON extraction differences; cap at 500 for safety
         if ($this->sort !== 'fastest') {
-            $query->limit($this->perPage + 1);
+            $query->skip($this->offset)->limit($this->perPage + 1);
         } else {
             $query->limit(500);
         }
@@ -54,11 +57,13 @@ class TrendingFeed extends Component
                 ->values();
 
             $this->hasMore = false;
+            $this->hasPrevious = false;
 
             return $results->take($this->perPage);
         }
 
         $this->hasMore = $results->count() > $this->perPage;
+        $this->hasPrevious = $this->offset > 0;
 
         return $results->take($this->perPage);
     }
@@ -97,7 +102,17 @@ class TrendingFeed extends Component
 
     public function loadMore(): void
     {
-        $this->perPage += 20;
+        if ($this->perPage < $this->maxWindow) {
+            $this->perPage += 20;
+        } else {
+            $this->offset += 20;
+        }
+        unset($this->trendingReturns);
+    }
+
+    public function loadPrevious(): void
+    {
+        $this->offset = max(0, $this->offset - 20);
         unset($this->trendingReturns);
     }
 
@@ -105,6 +120,7 @@ class TrendingFeed extends Component
     {
         $this->sort = $sort;
         $this->perPage = 20;
+        $this->offset = 0;
         unset($this->trendingReturns);
     }
 }

--- a/database/factories/FeedFactory.php
+++ b/database/factories/FeedFactory.php
@@ -68,6 +68,28 @@ class FeedFactory extends Factory
         ]);
     }
 
+    public function returnedPostalMail(?Player $player = null, ?User $user = null)
+    {
+        $user ??= User::factory()->create();
+        $player ??= Player::factory()->create();
+        $postalMail = PostalMail::factory()->returned()->create();
+
+        return $this->state([
+            'feedable_id' => $postalMail->id,
+            'feedable_type' => PostalMail::class,
+            'followable_id' => $user->id,
+            'meta' => [
+                'player' => $player->name,
+                'player_path' => $player->path(),
+                'user' => $user->name,
+                'user_path' => $user->path(),
+                'photo' => $user->profile_photo_url,
+                'date_sent' => now()->subWeek(),
+                'date_returned' => now()->subDay(),
+            ],
+        ]);
+    }
+
     public function forUser(User $user, $model = PostalMail::class)
     {
         return $this->state([

--- a/resources/views/livewire/trending-feed.blade.php
+++ b/resources/views/livewire/trending-feed.blade.php
@@ -66,9 +66,31 @@
                         </div>
                     </div>
 
+                    {{-- Load previous button --}}
+                    @if ($hasPrevious)
+                        <div x-data class="flex justify-center py-2">
+                            <button
+                                wire:loading.attr="disabled"
+                                @click="
+                                    $wire.loadPrevious().then(() => {
+                                        requestAnimationFrame(() => {
+                                            document.querySelectorAll('[data-trending-id]')[0]
+                                                ?.scrollIntoView({ block: 'start' });
+                                        });
+                                    });
+                                "
+                                class="text-sm font-medium text-[#D93C3F] hover:text-[#b82e31] transition-colors disabled:opacity-40"
+                            >
+                                &uarr; Load previous
+                            </button>
+                        </div>
+                    @endif
+
                     <div class="space-y-3">
                         @forelse ($this->trendingReturns as $feed)
-                            <x-feeds.celebration-card :$feed />
+                            <div wire:key="trending-{{ $feed->id }}" data-trending-id="{{ $feed->id }}">
+                                <x-feeds.celebration-card :$feed />
+                            </div>
                         @empty
                             <div class="text-center py-12 text-gray-400">
                                 <p class="text-sm">No trending returns yet.</p>
@@ -76,19 +98,44 @@
                         @endforelse
                     </div>
 
+                    {{-- Load more: auto-sentinel while growing, button once sliding --}}
                     @if ($hasMore)
-                        <div
-                            x-data
-                            x-init="
-                                const obs = new IntersectionObserver((entries) => {
-                                    if (entries[0].isIntersecting) { obs.disconnect(); $wire.loadMore(); }
-                                }, { rootMargin: '200px' });
-                                obs.observe($el);
-                            "
-                            class="flex justify-center py-6"
-                        >
-                            <div class="size-5 rounded-full border-2 border-[#D93C3F] border-t-transparent animate-spin opacity-60"></div>
-                        </div>
+                        @if ($perPage < $maxWindow)
+                            <div
+                                wire:key="trending-sentinel-{{ $perPage }}"
+                                x-data
+                                x-init="
+                                    requestAnimationFrame(() => {
+                                        const obs = new IntersectionObserver((entries) => {
+                                            if (!entries[0].isIntersecting) return;
+                                            obs.disconnect();
+                                            $wire.loadMore();
+                                        }, { rootMargin: '200px' });
+                                        obs.observe($el);
+                                    });
+                                "
+                                class="flex justify-center py-6"
+                            >
+                                <div class="size-5 rounded-full border-2 border-[#D93C3F] border-t-transparent animate-spin opacity-60"></div>
+                            </div>
+                        @else
+                            <div x-data class="flex justify-center py-2">
+                                <button
+                                    wire:loading.attr="disabled"
+                                    @click="
+                                        const lastEl = [...document.querySelectorAll('[data-trending-id]')].pop();
+                                        $wire.loadMore().then(() => {
+                                            requestAnimationFrame(() => {
+                                                lastEl?.scrollIntoView({ block: 'end' });
+                                            });
+                                        });
+                                    "
+                                    class="text-sm font-medium text-[#D93C3F] hover:text-[#b82e31] transition-colors disabled:opacity-40"
+                                >
+                                    Load more &darr;
+                                </button>
+                            </div>
+                        @endif
                     @endif
                 </div>
 

--- a/tests/Feature/Livewire/TrendingFeedTest.php
+++ b/tests/Feature/Livewire/TrendingFeedTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Livewire\TrendingFeed;
+use App\Models\Feed;
 use App\Models\Player;
 use App\Models\PostalMail;
 use App\Models\Signer;
@@ -22,6 +23,68 @@ it('renders without a GROUP BY error', function () {
     Livewire::actingAs(User::factory()->create())
         ->test(TrendingFeed::class)
         ->assertStatus(200);
+});
+
+test('loadMore grows the window until maxWindow then slides the offset', function () {
+    Feed::factory(80)->returnedPostalMail()->create();
+
+    $component = Livewire::actingAs(User::factory()->create())
+        ->test(TrendingFeed::class);
+
+    expect($component->instance()->trendingReturns)->toHaveCount(20);
+    expect($component->get('hasPrevious'))->toBeFalse();
+
+    $component->call('loadMore'); // perPage 40
+    expect($component->instance()->trendingReturns)->toHaveCount(40);
+
+    $component->call('loadMore'); // perPage 60
+    expect($component->instance()->trendingReturns)->toHaveCount(60);
+
+    // Window full — next loadMore slides instead of growing
+    $component->call('loadMore'); // offset 20
+    expect($component->instance()->trendingReturns)->toHaveCount(60);
+    expect($component->get('offset'))->toBe(20);
+    expect($component->get('hasPrevious'))->toBeTrue();
+});
+
+test('loadPrevious decrements offset and clamps at zero', function () {
+    Feed::factory(80)->returnedPostalMail()->create();
+
+    $component = Livewire::actingAs(User::factory()->create())
+        ->test(TrendingFeed::class);
+
+    $component->call('loadMore'); // 40
+    $component->call('loadMore'); // 60
+    $component->call('loadMore'); // offset 20
+    $component->call('loadMore'); // offset 40
+
+    expect($component->get('offset'))->toBe(40);
+
+    $component->call('loadPrevious');
+    expect($component->get('offset'))->toBe(20);
+
+    $component->call('loadPrevious');
+    expect($component->get('offset'))->toBe(0);
+    expect($component->get('hasPrevious'))->toBeFalse();
+
+    $component->call('loadPrevious'); // clamps
+    expect($component->get('offset'))->toBe(0);
+});
+
+test('setSort resets offset and perPage', function () {
+    Feed::factory(80)->returnedPostalMail()->create();
+
+    $component = Livewire::actingAs(User::factory()->create())
+        ->test(TrendingFeed::class);
+
+    $component->call('loadMore');
+    $component->call('loadMore');
+    $component->call('loadMore'); // offset now 20
+
+    $component->call('setSort', 'comments');
+
+    expect($component->get('offset'))->toBe(0);
+    expect($component->get('perPage'))->toBe(20);
 });
 
 it('shows the trending players ranked by send count', function () {


### PR DESCRIPTION
## Summary

- Mirrors the UserFeed sliding window pattern on the `/trending` page
- 60-item window (3 pages of 20) with auto-sentinel while growing
- Once the window is full, Load More ↓ / ↑ Load previous buttons replace the sentinel
- `data-trending-id` anchors handle scroll compensation on button clicks
- `setSort` resets offset so switching sort tabs starts fresh
- Adds a `returnedPostalMail` factory state for cleaner test setup

## Test plan

- [ ] Auto-sentinel loads first 60 items without looping
- [ ] At 60 items the sentinel is replaced by a Load More button; clicking it slides the window and scrolls to the content boundary
- [ ] Load Previous button appears and works correctly
- [ ] Switching sort tabs resets back to the first page
- [ ] All 5 `TrendingFeedTest` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)