### PR TITLE
Convert snapshot card to Tailwind with mobile-responsive layout

### DIFF
--- a/docs/snapshot-og-image.md
+++ b/docs/snapshot-og-image.md
@@ -1,0 +1,31 @@
+# Snapshot Page — OG Image Generation
+
+## Goal
+
+When a user shares their snapshot URL (e.g. on Twitter, iMessage, Discord), the stats card should appear as the link preview image rather than a generic fallback.
+
+## Approach: Sidecar + Browsershot
+
+Use [Sidecar](https://hammerstone.dev/sidecar/docs) (by Aaron Francis) to invoke a Node.js AWS Lambda function that runs Puppeteer/Chromium, screenshots the snapshot page's stats card, and stores the result on S3.
+
+**Why this approach:**
+- No Chrome/Chromium needed on the Cloudways server
+- Lambda costs are effectively free at our volume (within AWS free tier)
+- S3 is already configured — store the image there and serve it directly
+- The OG image automatically matches the Blade component exactly, no reimplementation needed
+- Once generated, subsequent shares are just an S3 read
+
+## Implementation sketch
+
+1. Install `hammerstone/sidecar` and configure a `ScreenshotFunction` Lambda (Node.js, with a Chromium layer)
+2. On first visit to a snapshot URL, dispatch a queued job that:
+   - Invokes the Sidecar function with the snapshot URL
+   - Receives the PNG back and stores it at `snapshots/{user}/{year}.png` on S3
+3. Add OG meta tags to `snapshot-card.blade.php` via `@push('head')` — pattern already exists on `show-return.blade.php`
+4. Image URL can be a public S3 URL or a signed URL depending on bucket visibility
+
+## Reference
+
+- Pattern to follow for OG tags: `resources/views/livewire/show-return.blade.php`
+- Pattern to follow for image storage: `app/Services/ReturnCardService.php`
+- Sidecar docs: https://hammerstone.dev/sidecar/docs

--- a/resources/views/components/stats-card.blade.php
+++ b/resources/views/components/stats-card.blade.php
@@ -1,0 +1,104 @@
+@props(['stats'])
+
+<div {{ $attributes->merge(['class' => 'rounded-2xl p-6 sm:p-8 md:p-10 text-white font-sans']) }} style="background-color:#D93C3F;">
+
+    {{-- Header --}}
+    <div class="flex items-center justify-between mb-7 sm:mb-10 gap-2">
+        {{ $header }}
+    </div>
+
+    {{-- 4 headline numbers --}}
+    <div class="grid grid-cols-2 sm:grid-cols-4 gap-5 sm:gap-6 mb-7 sm:mb-10">
+        <div>
+            <p class="text-[clamp(22px,7vw,80px)] font-black leading-none tabular-nums">{{ data_get($stats, 'total_sends', 0) }}</p>
+            <p class="text-[10px] sm:text-[11px] font-bold tracking-widest uppercase text-white/70 mt-2 sm:mt-3">Sends</p>
+        </div>
+        <div>
+            <p class="text-[clamp(22px,7vw,80px)] font-black leading-none tabular-nums">{{ data_get($stats, 'total_returns', 0) }}</p>
+            <p class="text-[10px] sm:text-[11px] font-bold tracking-widest uppercase text-white/70 mt-2 sm:mt-3">Returns</p>
+        </div>
+        <div>
+            <p class="text-[clamp(22px,7vw,80px)] font-black leading-none tabular-nums">{{ data_get($stats, 'success_rate', 0) }}<span class="text-[clamp(12px,3.5vw,40px)] font-black">%</span></p>
+            <p class="text-[10px] sm:text-[11px] font-bold tracking-widest uppercase text-white/70 mt-2 sm:mt-3">Success</p>
+        </div>
+        <div>
+            <p class="text-[clamp(22px,7vw,80px)] font-black leading-none tabular-nums">{{ data_get($stats, 'unique_players', 0) }}</p>
+            <p class="text-[10px] sm:text-[11px] font-bold tracking-widest uppercase text-white/70 mt-2 sm:mt-3">Players</p>
+        </div>
+    </div>
+
+    {{-- Divider --}}
+    <div class="border-t border-white/20 mb-6"></div>
+
+    {{-- Detail rows --}}
+    <div class="flex flex-col gap-4">
+        @if (data_get($stats, 'fastest_return'))
+            <div class="flex justify-between items-center text-sm font-medium gap-2">
+                <div class="flex items-center gap-3 shrink-0">
+                    <x-heroicon-o-bolt class="size-4 sm:size-5 text-white/70 shrink-0" />
+                    Fastest Return
+                </div>
+                <span class="text-sm font-semibold text-right">{{ data_get($stats, 'fastest_return.player_name') }} · {{ data_get($stats, 'fastest_return.days') }} days</span>
+            </div>
+        @endif
+        @if (data_get($stats, 'longest_wait'))
+            <div class="flex justify-between items-center text-sm font-medium gap-2">
+                <div class="flex items-center gap-3 shrink-0">
+                    <x-heroicon-o-clock class="size-4 sm:size-5 text-white/70 shrink-0" />
+                    Longest Wait
+                </div>
+                <span class="text-sm font-semibold text-right">{{ data_get($stats, 'longest_wait.player_name') }} · {{ data_get($stats, 'longest_wait.days') }} days</span>
+            </div>
+        @endif
+        @if (data_get($stats, 'favorite_team'))
+            <div class="flex justify-between items-center text-sm font-medium gap-2">
+                <div class="flex items-center gap-3 shrink-0">
+                    <x-heroicon-o-trophy class="size-4 sm:size-5 text-white/70 shrink-0" />
+                    Favorite Team
+                </div>
+                <span class="text-sm font-semibold text-right">{{ data_get($stats, 'favorite_team') }}</span>
+            </div>
+        @endif
+        @if (data_get($stats, 'favorite_category'))
+            <div class="flex justify-between items-center text-sm font-medium gap-2">
+                <div class="flex items-center gap-3 shrink-0">
+                    <x-heroicon-o-tag class="size-4 sm:size-5 text-white/70 shrink-0" />
+                    Top Category
+                </div>
+                <span class="text-sm font-semibold text-right">{{ data_get($stats, 'favorite_category') }}</span>
+            </div>
+        @endif
+        @if (data_get($stats, 'most_reacted_return'))
+            <div class="flex justify-between items-center text-sm font-medium gap-2">
+                <div class="flex items-center gap-3 shrink-0">
+                    <x-heroicon-s-heart class="size-4 sm:size-5 text-white/70 shrink-0" />
+                    Most Reacted
+                </div>
+                <span class="text-sm font-semibold text-right">{{ data_get($stats, 'most_reacted_return.player_name') }} · {{ data_get($stats, 'most_reacted_return.reaction_count') }} reactions</span>
+            </div>
+        @endif
+        @if (data_get($stats, 'first_send'))
+            @php $firstSend = data_get($stats, 'first_send'); @endphp
+            <div class="flex justify-between items-center text-sm font-medium gap-2">
+                <div class="flex items-center gap-3 shrink-0">
+                    <x-heroicon-o-paper-airplane class="size-4 sm:size-5 text-white/70 shrink-0" />
+                    First Send
+                </div>
+                <span class="text-sm font-semibold text-right">{{ ($firstSend instanceof \Carbon\Carbon ? $firstSend : \Carbon\Carbon::parse($firstSend))->format('M j, Y') }}</span>
+            </div>
+        @endif
+        @if (data_get($stats, 'most_recent_return'))
+            @php $latestReturn = data_get($stats, 'most_recent_return'); @endphp
+            <div class="flex justify-between items-center text-sm font-medium gap-2">
+                <div class="flex items-center gap-3 shrink-0">
+                    <x-heroicon-o-inbox-arrow-down class="size-4 sm:size-5 text-white/70 shrink-0" />
+                    Latest Return
+                </div>
+                <span class="text-sm font-semibold text-right">{{ ($latestReturn instanceof \Carbon\Carbon ? $latestReturn : \Carbon\Carbon::parse($latestReturn))->format('M j, Y') }}</span>
+            </div>
+        @endif
+        @if (data_get($stats, 'total_sends', 0) === 0)
+            <p class="text-white/50 text-sm text-center py-2">No activity yet — send some mail to see stats here.</p>
+        @endif
+    </div>
+</div>

--- a/resources/views/livewire/user-profile.blade.php
+++ b/resources/views/livewire/user-profile.blade.php
@@ -42,111 +42,16 @@
     <div class="px-4 space-y-8 mt-4">
 
         {{-- Stats card --}}
-        <div class="rounded-2xl p-8 md:p-10 text-white" style="background-color:#D93C3F; font-family:'Inter',sans-serif;">
-
-            {{-- Header --}}
-            <div class="flex items-center justify-between mb-10">
+        <x-stats-card :stats="$this->stats">
+            <x-slot:header>
                 <p class="text-xs font-bold uppercase tracking-widest">All-Time Stats</p>
                 <a href="{{ route('users.snapshot', [$this->user, now()->year]) }}"
-                   class="bg-white rounded-full px-5 py-2 text-xs font-black uppercase tracking-widest hover:bg-white/90 transition-colors"
+                   class="bg-white rounded-full px-5 py-2 text-xs font-black uppercase tracking-widest hover:bg-white/90 transition-colors shrink-0"
                    style="color:#D93C3F;">
                     Share Snapshot ↗
                 </a>
-            </div>
-
-            {{-- 4 headline numbers --}}
-            <div class="grid grid-cols-2 md:grid-cols-4 gap-6 mb-10">
-                <div>
-                    <p class="text-8xl font-black leading-none tabular-nums">{{ $this->stats['total_sends'] }}</p>
-                    <p class="text-xs font-bold uppercase tracking-widest mt-3 text-white/70">Sends</p>
-                </div>
-                <div>
-                    <p class="text-8xl font-black leading-none tabular-nums">{{ $this->stats['total_returns'] }}</p>
-                    <p class="text-xs font-bold uppercase tracking-widest mt-3 text-white/70">Returns</p>
-                </div>
-                <div>
-                    <p class="text-8xl font-black leading-none tabular-nums">{{ $this->stats['success_rate'] }}<span class="text-4xl font-black">%</span></p>
-                    <p class="text-xs font-bold uppercase tracking-widest mt-3 text-white/70">Success</p>
-                </div>
-                <div>
-                    <p class="text-8xl font-black leading-none tabular-nums">{{ $this->stats['unique_players'] }}</p>
-                    <p class="text-xs font-bold uppercase tracking-widest mt-3 text-white/70">Players</p>
-                </div>
-            </div>
-
-            {{-- Divider --}}
-            <div class="border-t border-white/20 mb-6"></div>
-
-            {{-- Detail rows --}}
-            <div class="space-y-4">
-                @if ($this->stats['fastest_return'])
-                    <div class="flex items-center justify-between">
-                        <div class="flex items-center gap-3 text-sm font-medium">
-                            <x-heroicon-o-bolt class="size-5 text-white/70 shrink-0" />
-                            Fastest Return
-                        </div>
-                        <span class="text-sm font-semibold">{{ $this->stats['fastest_return']['player_name'] }} · {{ $this->stats['fastest_return']['days'] }} days</span>
-                    </div>
-                @endif
-                @if ($this->stats['longest_wait'])
-                    <div class="flex items-center justify-between">
-                        <div class="flex items-center gap-3 text-sm font-medium">
-                            <x-heroicon-o-clock class="size-5 text-white/70 shrink-0" />
-                            Longest Wait
-                        </div>
-                        <span class="text-sm font-semibold">{{ $this->stats['longest_wait']['player_name'] }} · {{ $this->stats['longest_wait']['days'] }} days</span>
-                    </div>
-                @endif
-                @if ($this->stats['favorite_team'])
-                    <div class="flex items-center justify-between">
-                        <div class="flex items-center gap-3 text-sm font-medium">
-                            <x-heroicon-o-trophy class="size-5 text-white/70 shrink-0" />
-                            Favorite Team
-                        </div>
-                        <span class="text-sm font-semibold">{{ $this->stats['favorite_team'] }}</span>
-                    </div>
-                @endif
-                @if ($this->stats['favorite_category'])
-                    <div class="flex items-center justify-between">
-                        <div class="flex items-center gap-3 text-sm font-medium">
-                            <x-heroicon-o-tag class="size-5 text-white/70 shrink-0" />
-                            Top Category
-                        </div>
-                        <span class="text-sm font-semibold">{{ $this->stats['favorite_category'] }}</span>
-                    </div>
-                @endif
-                @if ($this->stats['most_reacted_return'])
-                    <div class="flex items-center justify-between">
-                        <div class="flex items-center gap-3 text-sm font-medium">
-                            <x-heroicon-s-heart class="size-5 text-white/70 shrink-0" />
-                            Most Reacted
-                        </div>
-                        <span class="text-sm font-semibold">{{ $this->stats['most_reacted_return']['player_name'] }} · {{ $this->stats['most_reacted_return']['reaction_count'] }} reactions</span>
-                    </div>
-                @endif
-                @if ($this->stats['first_send'])
-                    <div class="flex items-center justify-between">
-                        <div class="flex items-center gap-3 text-sm font-medium">
-                            <x-heroicon-o-paper-airplane class="size-5 text-white/70 shrink-0" />
-                            First Send
-                        </div>
-                        <span class="text-sm font-semibold">{{ $this->stats['first_send']->format('M j, Y') }}</span>
-                    </div>
-                @endif
-                @if ($this->stats['most_recent_return'])
-                    <div class="flex items-center justify-between">
-                        <div class="flex items-center gap-3 text-sm font-medium">
-                            <x-heroicon-o-inbox-arrow-down class="size-5 text-white/70 shrink-0" />
-                            Latest Return
-                        </div>
-                        <span class="text-sm font-semibold">{{ $this->stats['most_recent_return']->format('M j, Y') }}</span>
-                    </div>
-                @endif
-                @if ($this->stats['total_sends'] === 0)
-                    <p class="text-white/50 text-sm text-center py-2">No activity yet — send some mail to see stats here.</p>
-                @endif
-            </div>
-        </div>
+            </x-slot:header>
+        </x-stats-card>
 
         {{-- Past Snapshots --}}
         @if ($this->snapshots->isNotEmpty())

--- a/resources/views/snapshot-card.blade.php
+++ b/resources/views/snapshot-card.blade.php
@@ -6,182 +6,121 @@
     <title>{{ $user->name }} · {{ $year }} Snapshot</title>
     <link rel="preconnect" href="https://fonts.bunny.net">
     <link href="https://fonts.bunny.net/css?family=inter:400,500,600,700,800,900&display=swap" rel="stylesheet">
-    <style>
-        * { margin: 0; padding: 0; box-sizing: border-box; }
-        body {
-            background: #f3f4f6;
-            display: flex; flex-direction: column; align-items: center; justify-content: flex-start;
-            min-height: 100vh; padding: 2rem;
-            font-family: 'Inter', sans-serif;
-        }
-        #card {
-            width: 100%; max-width: 900px;
-            background: #D93C3F;
-            border-radius: 24px;
-            padding: 48px 56px;
-            color: white;
-        }
-        .header {
-            display: flex; justify-content: space-between; align-items: center;
-            margin-bottom: 48px;
-        }
-        .header-label {
-            font-size: 12px; font-weight: 700;
-            letter-spacing: 0.15em; text-transform: uppercase;
-        }
-        .year-pill {
-            background: white; color: #D93C3F;
-            border-radius: 9999px; padding: 8px 20px;
-            font-size: 12px; font-weight: 900;
-            letter-spacing: 0.15em; text-transform: uppercase;
-        }
-        .big-stats {
-            display: grid; grid-template-columns: repeat(4, 1fr); gap: 24px;
-            margin-bottom: 40px;
-        }
-        .stat-number {
-            font-size: 80px; font-weight: 900; line-height: 1;
-            font-variant-numeric: tabular-nums;
-        }
-        .stat-pct { font-size: 40px; font-weight: 900; }
-        .stat-label {
-            font-size: 11px; font-weight: 700;
-            letter-spacing: 0.15em; text-transform: uppercase;
-            color: rgba(255,255,255,0.7); margin-top: 12px;
-        }
-        .divider { border-top: 1px solid rgba(255,255,255,0.2); margin-bottom: 24px; }
-        .detail-rows { display: flex; flex-direction: column; gap: 16px; }
-        .detail-row { display: flex; justify-content: space-between; align-items: center; font-size: 14px; font-weight: 500; }
-        .detail-left { display: flex; align-items: center; gap: 12px; }
-        .detail-icon { width: 20px; height: 20px; flex-shrink: 0; opacity: 0.7; }
-        .detail-value { font-size: 14px; font-weight: 600; }
-        .controls {
-            display: flex; gap: 12px;
-            margin-top: 20px; max-width: 900px; width: 100%;
-            justify-content: flex-end;
-        }
-        .btn {
-            padding: 10px 20px; border-radius: 10px;
-            font-size: 14px; font-weight: 600; cursor: pointer; border: none;
-            font-family: 'Inter', sans-serif; text-decoration: none;
-            display: inline-flex; align-items: center; gap: 6px;
-        }
-        .btn-download { background: #D93C3F; color: white; }
-        .btn-back { background: #e5e7eb; color: #111827; }
-    </style>
+    @vite('resources/css/app.css')
 </head>
-<body>
+<body class="bg-gray-100 flex flex-col items-center justify-start min-h-screen p-4 sm:p-8 font-sans">
 
-<div id="card">
+<div id="card" class="w-full max-w-[900px] rounded-3xl py-6 px-5 sm:py-12 sm:px-14 text-white" style="background-color:#D93C3F;">
+
     {{-- Header --}}
-    <div class="header">
-        <p class="header-label">{{ $user->name }} · All-Time Stats</p>
-        <span class="year-pill">{{ $year }} Snapshot</span>
+    <div class="flex justify-between items-center mb-7 sm:mb-12 gap-2">
+        <p class="text-[10px] sm:text-xs font-bold tracking-widest uppercase">{{ $user->name }} · All-Time Stats</p>
+        <span class="bg-white rounded-full px-4 sm:px-5 py-1.5 sm:py-2 text-[10px] sm:text-xs font-black tracking-widest uppercase shrink-0" style="color:#D93C3F;">{{ $year }} Snapshot</span>
     </div>
 
     {{-- 4 headline numbers --}}
-    <div class="big-stats">
+    <div class="grid grid-cols-2 sm:grid-cols-4 gap-5 sm:gap-6 mb-7 sm:mb-10">
         <div>
-            <p class="stat-number">{{ data_get($stats, 'total_sends', 0) }}</p>
-            <p class="stat-label">Sends</p>
+            <p class="text-[clamp(22px,7vw,80px)] font-black leading-none tabular-nums">{{ data_get($stats, 'total_sends', 0) }}</p>
+            <p class="text-[10px] sm:text-[11px] font-bold tracking-widest uppercase text-white/70 mt-2 sm:mt-3">Sends</p>
         </div>
         <div>
-            <p class="stat-number">{{ data_get($stats, 'total_returns', 0) }}</p>
-            <p class="stat-label">Returns</p>
+            <p class="text-[clamp(22px,7vw,80px)] font-black leading-none tabular-nums">{{ data_get($stats, 'total_returns', 0) }}</p>
+            <p class="text-[10px] sm:text-[11px] font-bold tracking-widest uppercase text-white/70 mt-2 sm:mt-3">Returns</p>
         </div>
         <div>
-            <p class="stat-number">{{ data_get($stats, 'success_rate', 0) }}<span class="stat-pct">%</span></p>
-            <p class="stat-label">Success</p>
+            <p class="text-[clamp(22px,7vw,80px)] font-black leading-none tabular-nums">{{ data_get($stats, 'success_rate', 0) }}<span class="text-[clamp(12px,3.5vw,40px)] font-black">%</span></p>
+            <p class="text-[10px] sm:text-[11px] font-bold tracking-widest uppercase text-white/70 mt-2 sm:mt-3">Success</p>
         </div>
         <div>
-            <p class="stat-number">{{ data_get($stats, 'unique_players', 0) }}</p>
-            <p class="stat-label">Players</p>
+            <p class="text-[clamp(22px,7vw,80px)] font-black leading-none tabular-nums">{{ data_get($stats, 'unique_players', 0) }}</p>
+            <p class="text-[10px] sm:text-[11px] font-bold tracking-widest uppercase text-white/70 mt-2 sm:mt-3">Players</p>
         </div>
     </div>
 
     {{-- Divider --}}
-    <div class="divider"></div>
+    <div class="border-t border-white/20 mb-6"></div>
 
     {{-- Detail rows --}}
-    <div class="detail-rows">
+    <div class="flex flex-col gap-4">
         @if (data_get($stats, 'fastest_return'))
-            <div class="detail-row">
-                <div class="detail-left">
-                    <svg class="detail-icon" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="white"><path stroke-linecap="round" stroke-linejoin="round" d="m3.75 13.5 10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75z" /></svg>
+            <div class="flex justify-between items-center text-sm font-medium gap-2">
+                <div class="flex items-center gap-2 sm:gap-3 shrink-0">
+                    <svg class="size-4 sm:size-5 shrink-0 opacity-70" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="white"><path stroke-linecap="round" stroke-linejoin="round" d="m3.75 13.5 10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75z" /></svg>
                     Fastest Return
                 </div>
-                <span class="detail-value">{{ data_get($stats, 'fastest_return.player_name') }} · {{ data_get($stats, 'fastest_return.days') }} days</span>
+                <span class="text-sm font-semibold text-right">{{ data_get($stats, 'fastest_return.player_name') }} · {{ data_get($stats, 'fastest_return.days') }} days</span>
             </div>
         @endif
         @if (data_get($stats, 'longest_wait'))
-            <div class="detail-row">
-                <div class="detail-left">
-                    <svg class="detail-icon" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="white"><path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0z" /></svg>
+            <div class="flex justify-between items-center text-sm font-medium gap-2">
+                <div class="flex items-center gap-2 sm:gap-3 shrink-0">
+                    <svg class="size-4 sm:size-5 shrink-0 opacity-70" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="white"><path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0z" /></svg>
                     Longest Wait
                 </div>
-                <span class="detail-value">{{ data_get($stats, 'longest_wait.player_name') }} · {{ data_get($stats, 'longest_wait.days') }} days</span>
+                <span class="text-sm font-semibold text-right">{{ data_get($stats, 'longest_wait.player_name') }} · {{ data_get($stats, 'longest_wait.days') }} days</span>
             </div>
         @endif
         @if (data_get($stats, 'favorite_team'))
-            <div class="detail-row">
-                <div class="detail-left">
-                    <svg class="detail-icon" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="white"><path stroke-linecap="round" stroke-linejoin="round" d="M16.5 18.75h-9m9 0a3 3 0 0 1 3 3h-15a3 3 0 0 1 3-3m9 0v-3.375c0-.621-.503-1.125-1.125-1.125h-.871M7.5 18.75v-3.375c0-.621.504-1.125 1.125-1.125h.872m5.007 0H9.497m5.007 0a7.454 7.454 0 0 1-.982-3.172M9.497 14.25a7.454 7.454 0 0 0 .981-3.172M5.25 4.236c-.982.143-1.954.317-2.916.52A6.003 6.003 0 0 0 7.73 9.728M5.25 4.236V4.5c0 2.108.966 3.99 2.48 5.228M5.25 4.236V2.721C7.456 2.41 9.71 2.25 12 2.25c2.291 0 4.545.16 6.75.47v1.516M7.73 9.728a6.726 6.726 0 0 0 2.748 1.35m8.272-6.842V4.5c0 2.108-.966 3.99-2.48 5.228m2.48-5.492a46.32 46.32 0 0 1 2.916.52 6.003 6.003 0 0 1-5.395 4.972m0 0a6.726 6.726 0 0 1-2.749 1.35m0 0a6.772 6.772 0 0 1-3.044 0" /></svg>
+            <div class="flex justify-between items-center text-sm font-medium gap-2">
+                <div class="flex items-center gap-2 sm:gap-3 shrink-0">
+                    <svg class="size-4 sm:size-5 shrink-0 opacity-70" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="white"><path stroke-linecap="round" stroke-linejoin="round" d="M16.5 18.75h-9m9 0a3 3 0 0 1 3 3h-15a3 3 0 0 1 3-3m9 0v-3.375c0-.621-.503-1.125-1.125-1.125h-.871M7.5 18.75v-3.375c0-.621.504-1.125 1.125-1.125h.872m5.007 0H9.497m5.007 0a7.454 7.454 0 0 1-.982-3.172M9.497 14.25a7.454 7.454 0 0 0 .981-3.172M5.25 4.236c-.982.143-1.954.317-2.916.52A6.003 6.003 0 0 0 7.73 9.728M5.25 4.236V4.5c0 2.108.966 3.99 2.48 5.228M5.25 4.236V2.721C7.456 2.41 9.71 2.25 12 2.25c2.291 0 4.545.16 6.75.47v1.516M7.73 9.728a6.726 6.726 0 0 0 2.748 1.35m8.272-6.842V4.5c0 2.108-.966 3.99-2.48 5.228m2.48-5.492a46.32 46.32 0 0 1 2.916.52 6.003 6.003 0 0 1-5.395 4.972m0 0a6.726 6.726 0 0 1-2.749 1.35m0 0a6.772 6.772 0 0 1-3.044 0" /></svg>
                     Favorite Team
                 </div>
-                <span class="detail-value">{{ data_get($stats, 'favorite_team') }}</span>
+                <span class="text-sm font-semibold text-right">{{ data_get($stats, 'favorite_team') }}</span>
             </div>
         @endif
         @if (data_get($stats, 'favorite_category'))
-            <div class="detail-row">
-                <div class="detail-left">
-                    <svg class="detail-icon" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="white"><path stroke-linecap="round" stroke-linejoin="round" d="M9.568 3H5.25A2.25 2.25 0 0 0 3 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 0 0 5.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 0 0 9.568 3z" /><path stroke-linecap="round" stroke-linejoin="round" d="M6 6h.008v.008H6V6z" /></svg>
+            <div class="flex justify-between items-center text-sm font-medium gap-2">
+                <div class="flex items-center gap-2 sm:gap-3 shrink-0">
+                    <svg class="size-4 sm:size-5 shrink-0 opacity-70" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="white"><path stroke-linecap="round" stroke-linejoin="round" d="M9.568 3H5.25A2.25 2.25 0 0 0 3 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 0 0 5.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 0 0 9.568 3z" /><path stroke-linecap="round" stroke-linejoin="round" d="M6 6h.008v.008H6V6z" /></svg>
                     Top Category
                 </div>
-                <span class="detail-value">{{ data_get($stats, 'favorite_category') }}</span>
+                <span class="text-sm font-semibold text-right">{{ data_get($stats, 'favorite_category') }}</span>
             </div>
         @endif
         @if (data_get($stats, 'most_reacted_return'))
-            <div class="detail-row">
-                <div class="detail-left">
-                    <svg class="detail-icon" fill="white" viewBox="0 0 24 24"><path d="m11.645 20.91-.007-.003-.022-.012a15.247 15.247 0 0 1-.383-.218 25.18 25.18 0 0 1-4.244-3.17C4.688 15.36 2.25 12.174 2.25 8.25 2.25 5.322 4.714 3 7.688 3A5.5 5.5 0 0 1 12 5.052 5.5 5.5 0 0 1 16.313 3c2.973 0 5.437 2.322 5.437 5.25 0 3.925-2.438 7.111-4.739 9.256a25.175 25.175 0 0 1-4.244 3.17 15.247 15.247 0 0 1-.383.219l-.022.012-.007.004-.003.001a.752.752 0 0 1-.704 0l-.003-.001z" /></svg>
+            <div class="flex justify-between items-center text-sm font-medium gap-2">
+                <div class="flex items-center gap-2 sm:gap-3 shrink-0">
+                    <svg class="size-4 sm:size-5 shrink-0 opacity-70" fill="white" viewBox="0 0 24 24"><path d="m11.645 20.91-.007-.003-.022-.012a15.247 15.247 0 0 1-.383-.218 25.18 25.18 0 0 1-4.244-3.17C4.688 15.36 2.25 12.174 2.25 8.25 2.25 5.322 4.714 3 7.688 3A5.5 5.5 0 0 1 12 5.052 5.5 5.5 0 0 1 16.313 3c2.973 0 5.437 2.322 5.437 5.25 0 3.925-2.438 7.111-4.739 9.256a25.175 25.175 0 0 1-4.244 3.17 15.247 15.247 0 0 1-.383.219l-.022.012-.007.004-.003.001a.752.752 0 0 1-.704 0l-.003-.001z" /></svg>
                     Most Reacted
                 </div>
-                <span class="detail-value">{{ data_get($stats, 'most_reacted_return.player_name') }} · {{ data_get($stats, 'most_reacted_return.reaction_count') }} reactions</span>
+                <span class="text-sm font-semibold text-right">{{ data_get($stats, 'most_reacted_return.player_name') }} · {{ data_get($stats, 'most_reacted_return.reaction_count') }} reactions</span>
             </div>
         @endif
         @if (data_get($stats, 'first_send'))
-            <div class="detail-row">
-                <div class="detail-left">
-                    <svg class="detail-icon" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="white"><path stroke-linecap="round" stroke-linejoin="round" d="M6 12 3.269 3.125A59.769 59.769 0 0 1 21.485 12 59.768 59.768 0 0 1 3.27 20.875L5.999 12zm0 0h7.5" /></svg>
+            <div class="flex justify-between items-center text-sm font-medium gap-2">
+                <div class="flex items-center gap-2 sm:gap-3 shrink-0">
+                    <svg class="size-4 sm:size-5 shrink-0 opacity-70" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="white"><path stroke-linecap="round" stroke-linejoin="round" d="M6 12 3.269 3.125A59.769 59.769 0 0 1 21.485 12 59.768 59.768 0 0 1 3.27 20.875L5.999 12zm0 0h7.5" /></svg>
                     First Send
                 </div>
-                <span class="detail-value">
+                <span class="text-sm font-semibold text-right">
                     @php $firstSend = data_get($stats, 'first_send'); @endphp
                     {{ ($firstSend instanceof \Carbon\Carbon ? $firstSend : \Carbon\Carbon::parse($firstSend))->format('M j, Y') }}
                 </span>
             </div>
         @endif
         @if (data_get($stats, 'most_recent_return'))
-            <div class="detail-row">
-                <div class="detail-left">
-                    <svg class="detail-icon" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="white"><path stroke-linecap="round" stroke-linejoin="round" d="M9 3.75H6.912a2.25 2.25 0 0 0-2.15 1.588L2.35 13.177a2.25 2.25 0 0 0-.1.661V18a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18v-4.162c0-.224-.034-.447-.1-.661L19.24 5.338a2.25 2.25 0 0 0-2.15-1.588H15M2.25 13.5h3.86a2.25 2.25 0 0 1 2.012 1.244l.256.512a2.25 2.25 0 0 0 2.013 1.244h3.218a2.25 2.25 0 0 0 2.013-1.244l.256-.512a2.25 2.25 0 0 1 2.013-1.244h3.859M12 3v8.25m0 0-3-3m3 3 3-3" /></svg>
+            <div class="flex justify-between items-center text-sm font-medium gap-2">
+                <div class="flex items-center gap-2 sm:gap-3 shrink-0">
+                    <svg class="size-4 sm:size-5 shrink-0 opacity-70" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="white"><path stroke-linecap="round" stroke-linejoin="round" d="M9 3.75H6.912a2.25 2.25 0 0 0-2.15 1.588L2.35 13.177a2.25 2.25 0 0 0-.1.661V18a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18v-4.162c0-.224-.034-.447-.1-.661L19.24 5.338a2.25 2.25 0 0 0-2.15-1.588H15M2.25 13.5h3.86a2.25 2.25 0 0 1 2.012 1.244l.256.512a2.25 2.25 0 0 0 2.013 1.244h3.218a2.25 2.25 0 0 0 2.013-1.244l.256-.512a2.25 2.25 0 0 1 2.013-1.244h3.859M12 3v8.25m0 0-3-3m3 3 3-3" /></svg>
                     Latest Return
                 </div>
-                <span class="detail-value">
+                <span class="text-sm font-semibold text-right">
                     @php $latestReturn = data_get($stats, 'most_recent_return'); @endphp
                     {{ ($latestReturn instanceof \Carbon\Carbon ? $latestReturn : \Carbon\Carbon::parse($latestReturn))->format('M j, Y') }}
                 </span>
             </div>
         @endif
         @if (data_get($stats, 'total_sends', 0) === 0)
-            <p style="color:rgba(255,255,255,0.5); font-size:14px; text-align:center; padding: 8px 0;">No activity yet for {{ $year }}.</p>
+            <p class="text-white/50 text-sm text-center py-2">No activity yet for {{ $year }}.</p>
         @endif
     </div>
 </div>
 
-<div class="controls">
-    <a href="{{ route('users.profile', $user) }}" class="btn btn-back">← Back</a>
-    <button class="btn btn-download" onclick="downloadCard()">Download Image</button>
+<div class="flex gap-3 mt-5 w-full max-w-[900px] justify-end">
+    <a href="{{ route('users.profile', $user) }}" class="px-5 py-2.5 rounded-xl text-sm font-semibold inline-flex items-center gap-1.5 no-underline bg-gray-200 text-gray-900">← Back</a>
+    <button class="px-5 py-2.5 rounded-xl text-sm font-semibold cursor-pointer border-0 inline-flex items-center gap-1.5 text-white" style="background-color:#D93C3F;" onclick="downloadCard()">Download Image</button>
 </div>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>

--- a/resources/views/snapshot-card.blade.php
+++ b/resources/views/snapshot-card.blade.php
@@ -10,113 +10,12 @@
 </head>
 <body class="bg-gray-100 flex flex-col items-center justify-start min-h-screen p-4 sm:p-8 font-sans">
 
-<div id="card" class="w-full max-w-[900px] rounded-3xl py-6 px-5 sm:py-12 sm:px-14 text-white" style="background-color:#D93C3F;">
-
-    {{-- Header --}}
-    <div class="flex justify-between items-center mb-7 sm:mb-12 gap-2">
+<x-stats-card :stats="$stats" id="card" class="w-full max-w-[900px]">
+    <x-slot:header>
         <p class="text-[10px] sm:text-xs font-bold tracking-widest uppercase">{{ $user->name }} · All-Time Stats</p>
         <span class="bg-white rounded-full px-4 sm:px-5 py-1.5 sm:py-2 text-[10px] sm:text-xs font-black tracking-widest uppercase shrink-0" style="color:#D93C3F;">{{ $year }} Snapshot</span>
-    </div>
-
-    {{-- 4 headline numbers --}}
-    <div class="grid grid-cols-2 sm:grid-cols-4 gap-5 sm:gap-6 mb-7 sm:mb-10">
-        <div>
-            <p class="text-[clamp(22px,7vw,80px)] font-black leading-none tabular-nums">{{ data_get($stats, 'total_sends', 0) }}</p>
-            <p class="text-[10px] sm:text-[11px] font-bold tracking-widest uppercase text-white/70 mt-2 sm:mt-3">Sends</p>
-        </div>
-        <div>
-            <p class="text-[clamp(22px,7vw,80px)] font-black leading-none tabular-nums">{{ data_get($stats, 'total_returns', 0) }}</p>
-            <p class="text-[10px] sm:text-[11px] font-bold tracking-widest uppercase text-white/70 mt-2 sm:mt-3">Returns</p>
-        </div>
-        <div>
-            <p class="text-[clamp(22px,7vw,80px)] font-black leading-none tabular-nums">{{ data_get($stats, 'success_rate', 0) }}<span class="text-[clamp(12px,3.5vw,40px)] font-black">%</span></p>
-            <p class="text-[10px] sm:text-[11px] font-bold tracking-widest uppercase text-white/70 mt-2 sm:mt-3">Success</p>
-        </div>
-        <div>
-            <p class="text-[clamp(22px,7vw,80px)] font-black leading-none tabular-nums">{{ data_get($stats, 'unique_players', 0) }}</p>
-            <p class="text-[10px] sm:text-[11px] font-bold tracking-widest uppercase text-white/70 mt-2 sm:mt-3">Players</p>
-        </div>
-    </div>
-
-    {{-- Divider --}}
-    <div class="border-t border-white/20 mb-6"></div>
-
-    {{-- Detail rows --}}
-    <div class="flex flex-col gap-4">
-        @if (data_get($stats, 'fastest_return'))
-            <div class="flex justify-between items-center text-sm font-medium gap-2">
-                <div class="flex items-center gap-2 sm:gap-3 shrink-0">
-                    <svg class="size-4 sm:size-5 shrink-0 opacity-70" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="white"><path stroke-linecap="round" stroke-linejoin="round" d="m3.75 13.5 10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75z" /></svg>
-                    Fastest Return
-                </div>
-                <span class="text-sm font-semibold text-right">{{ data_get($stats, 'fastest_return.player_name') }} · {{ data_get($stats, 'fastest_return.days') }} days</span>
-            </div>
-        @endif
-        @if (data_get($stats, 'longest_wait'))
-            <div class="flex justify-between items-center text-sm font-medium gap-2">
-                <div class="flex items-center gap-2 sm:gap-3 shrink-0">
-                    <svg class="size-4 sm:size-5 shrink-0 opacity-70" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="white"><path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0z" /></svg>
-                    Longest Wait
-                </div>
-                <span class="text-sm font-semibold text-right">{{ data_get($stats, 'longest_wait.player_name') }} · {{ data_get($stats, 'longest_wait.days') }} days</span>
-            </div>
-        @endif
-        @if (data_get($stats, 'favorite_team'))
-            <div class="flex justify-between items-center text-sm font-medium gap-2">
-                <div class="flex items-center gap-2 sm:gap-3 shrink-0">
-                    <svg class="size-4 sm:size-5 shrink-0 opacity-70" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="white"><path stroke-linecap="round" stroke-linejoin="round" d="M16.5 18.75h-9m9 0a3 3 0 0 1 3 3h-15a3 3 0 0 1 3-3m9 0v-3.375c0-.621-.503-1.125-1.125-1.125h-.871M7.5 18.75v-3.375c0-.621.504-1.125 1.125-1.125h.872m5.007 0H9.497m5.007 0a7.454 7.454 0 0 1-.982-3.172M9.497 14.25a7.454 7.454 0 0 0 .981-3.172M5.25 4.236c-.982.143-1.954.317-2.916.52A6.003 6.003 0 0 0 7.73 9.728M5.25 4.236V4.5c0 2.108.966 3.99 2.48 5.228M5.25 4.236V2.721C7.456 2.41 9.71 2.25 12 2.25c2.291 0 4.545.16 6.75.47v1.516M7.73 9.728a6.726 6.726 0 0 0 2.748 1.35m8.272-6.842V4.5c0 2.108-.966 3.99-2.48 5.228m2.48-5.492a46.32 46.32 0 0 1 2.916.52 6.003 6.003 0 0 1-5.395 4.972m0 0a6.726 6.726 0 0 1-2.749 1.35m0 0a6.772 6.772 0 0 1-3.044 0" /></svg>
-                    Favorite Team
-                </div>
-                <span class="text-sm font-semibold text-right">{{ data_get($stats, 'favorite_team') }}</span>
-            </div>
-        @endif
-        @if (data_get($stats, 'favorite_category'))
-            <div class="flex justify-between items-center text-sm font-medium gap-2">
-                <div class="flex items-center gap-2 sm:gap-3 shrink-0">
-                    <svg class="size-4 sm:size-5 shrink-0 opacity-70" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="white"><path stroke-linecap="round" stroke-linejoin="round" d="M9.568 3H5.25A2.25 2.25 0 0 0 3 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 0 0 5.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 0 0 9.568 3z" /><path stroke-linecap="round" stroke-linejoin="round" d="M6 6h.008v.008H6V6z" /></svg>
-                    Top Category
-                </div>
-                <span class="text-sm font-semibold text-right">{{ data_get($stats, 'favorite_category') }}</span>
-            </div>
-        @endif
-        @if (data_get($stats, 'most_reacted_return'))
-            <div class="flex justify-between items-center text-sm font-medium gap-2">
-                <div class="flex items-center gap-2 sm:gap-3 shrink-0">
-                    <svg class="size-4 sm:size-5 shrink-0 opacity-70" fill="white" viewBox="0 0 24 24"><path d="m11.645 20.91-.007-.003-.022-.012a15.247 15.247 0 0 1-.383-.218 25.18 25.18 0 0 1-4.244-3.17C4.688 15.36 2.25 12.174 2.25 8.25 2.25 5.322 4.714 3 7.688 3A5.5 5.5 0 0 1 12 5.052 5.5 5.5 0 0 1 16.313 3c2.973 0 5.437 2.322 5.437 5.25 0 3.925-2.438 7.111-4.739 9.256a25.175 25.175 0 0 1-4.244 3.17 15.247 15.247 0 0 1-.383.219l-.022.012-.007.004-.003.001a.752.752 0 0 1-.704 0l-.003-.001z" /></svg>
-                    Most Reacted
-                </div>
-                <span class="text-sm font-semibold text-right">{{ data_get($stats, 'most_reacted_return.player_name') }} · {{ data_get($stats, 'most_reacted_return.reaction_count') }} reactions</span>
-            </div>
-        @endif
-        @if (data_get($stats, 'first_send'))
-            <div class="flex justify-between items-center text-sm font-medium gap-2">
-                <div class="flex items-center gap-2 sm:gap-3 shrink-0">
-                    <svg class="size-4 sm:size-5 shrink-0 opacity-70" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="white"><path stroke-linecap="round" stroke-linejoin="round" d="M6 12 3.269 3.125A59.769 59.769 0 0 1 21.485 12 59.768 59.768 0 0 1 3.27 20.875L5.999 12zm0 0h7.5" /></svg>
-                    First Send
-                </div>
-                <span class="text-sm font-semibold text-right">
-                    @php $firstSend = data_get($stats, 'first_send'); @endphp
-                    {{ ($firstSend instanceof \Carbon\Carbon ? $firstSend : \Carbon\Carbon::parse($firstSend))->format('M j, Y') }}
-                </span>
-            </div>
-        @endif
-        @if (data_get($stats, 'most_recent_return'))
-            <div class="flex justify-between items-center text-sm font-medium gap-2">
-                <div class="flex items-center gap-2 sm:gap-3 shrink-0">
-                    <svg class="size-4 sm:size-5 shrink-0 opacity-70" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="white"><path stroke-linecap="round" stroke-linejoin="round" d="M9 3.75H6.912a2.25 2.25 0 0 0-2.15 1.588L2.35 13.177a2.25 2.25 0 0 0-.1.661V18a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18v-4.162c0-.224-.034-.447-.1-.661L19.24 5.338a2.25 2.25 0 0 0-2.15-1.588H15M2.25 13.5h3.86a2.25 2.25 0 0 1 2.012 1.244l.256.512a2.25 2.25 0 0 0 2.013 1.244h3.218a2.25 2.25 0 0 0 2.013-1.244l.256-.512a2.25 2.25 0 0 1 2.013-1.244h3.859M12 3v8.25m0 0-3-3m3 3 3-3" /></svg>
-                    Latest Return
-                </div>
-                <span class="text-sm font-semibold text-right">
-                    @php $latestReturn = data_get($stats, 'most_recent_return'); @endphp
-                    {{ ($latestReturn instanceof \Carbon\Carbon ? $latestReturn : \Carbon\Carbon::parse($latestReturn))->format('M j, Y') }}
-                </span>
-            </div>
-        @endif
-        @if (data_get($stats, 'total_sends', 0) === 0)
-            <p class="text-white/50 text-sm text-center py-2">No activity yet for {{ $year }}.</p>
-        @endif
-    </div>
-</div>
+    </x-slot:header>
+</x-stats-card>
 
 <div class="flex gap-3 mt-5 w-full max-w-[900px] justify-end">
     <a href="{{ route('users.profile', $user) }}" class="px-5 py-2.5 rounded-xl text-sm font-semibold inline-flex items-center gap-1.5 no-underline bg-gray-200 text-gray-900">← Back</a>


### PR DESCRIPTION
## Summary

- Replaces the inline `<style>` block in `snapshot-card.blade.php` with Tailwind utility classes and `@vite('resources/css/app.css')`
- Stat numbers use `clamp(22px, 7vw, 80px)` for fluid font scaling — no hard breakpoint jump, and comfortable even with large 4-digit numbers on small screens
- Grid switches from a fixed 4-column layout to 2-column on mobile (`grid-cols-2 sm:grid-cols-4`)
- Card padding, pill sizes, and icon sizes also scale down for smaller viewports

## Test plan

- [ ] View the snapshot card on a desktop — stats should display at ~80px
- [ ] View on a mobile device or resize to ~375px — stats should scale down fluidly without overflowing
- [ ] Verify the Download Image button still works (html2canvas)
- [ ] Verify the Back link routes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)