### PR TITLE
Fix shop spotlight crash for imported shops with no user

### DIFF
--- a/database/migrations/2026_06_17_193015_make_followable_id_nullable_on_feeds_table.php
+++ b/database/migrations/2026_06_17_193015_make_followable_id_nullable_on_feeds_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('feeds', function (Blueprint $table) {
+            $table->unsignedBigInteger('followable_id')->nullable()->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('feeds', function (Blueprint $table) {
+            $table->unsignedBigInteger('followable_id')->nullable(false)->change();
+        });
+    }
+};

--- a/tests/Feature/Actions/CreateShopSpotlightFeedItemTest.php
+++ b/tests/Feature/Actions/CreateShopSpotlightFeedItemTest.php
@@ -1,0 +1,70 @@
+<?php
+
+use App\Actions\CreateShopSpotlightFeedItem;
+use App\Models\CardShop;
+use App\Models\Feed;
+use App\Models\User;
+
+test('it creates a feed item for the shop', function () {
+    $shop = CardShop::factory()->approved()->create();
+
+    CreateShopSpotlightFeedItem::execute($shop);
+
+    $this->assertDatabaseHas('feeds', [
+        'feedable_type' => CardShop::class,
+        'feedable_id' => $shop->id,
+        'followable_id' => $shop->user_id,
+    ]);
+});
+
+test('it creates a feed item with null followable_id when the shop has no user', function () {
+    $shop = CardShop::factory()->approved()->create(['user_id' => null]);
+
+    CreateShopSpotlightFeedItem::execute($shop);
+
+    $this->assertDatabaseHas('feeds', [
+        'feedable_type' => CardShop::class,
+        'feedable_id' => $shop->id,
+        'followable_id' => null,
+    ]);
+});
+
+test('it attaches to a recent digest from the same user', function () {
+    $user = User::factory()->create();
+    $shop = CardShop::factory()->approved()->for($user)->create();
+
+    $digest = Feed::create([
+        'followable_id' => $user->id,
+        'feedable_type' => CardShop::class,
+        'feedable_id' => $shop->id,
+        'comment' => '',
+        'meta' => array_merge($shop->generateMeta(), ['shop_ids' => [$shop->id]]),
+    ]);
+
+    $shop2 = CardShop::factory()->approved()->for($user)->create();
+
+    CreateShopSpotlightFeedItem::execute($shop2);
+
+    expect(Feed::count())->toBe(1);
+    expect($digest->fresh()->meta['shop_ids'])->toContain($shop2->id);
+});
+
+test('it creates a new feed if the digest is older than 60 minutes', function () {
+    $user = User::factory()->create();
+    $shop = CardShop::factory()->approved()->for($user)->create();
+
+    Feed::create([
+        'followable_id' => $user->id,
+        'feedable_type' => CardShop::class,
+        'feedable_id' => $shop->id,
+        'comment' => '',
+        'meta' => array_merge($shop->generateMeta(), ['shop_ids' => [$shop->id]]),
+        'created_at' => now()->subMinutes(61),
+    ]);
+
+    $shop2 = CardShop::factory()->approved()->for($user)->create();
+
+    CreateShopSpotlightFeedItem::execute($shop2);
+
+    expect(Feed::count())->toBe(2);
+});


### PR DESCRIPTION
## Summary

- Approving a card shop with no `user_id` (e.g. imported via Snakeysnake) was crashing with `Column 'followable_id' cannot be null` because `feeds.followable_id` had a NOT NULL constraint
- Made `followable_id` nullable via migration — shops without a user still create a feed item and appear in the global feed; they just won't appear on any user's profile feed or following feed (correct behaviour since there's no owner to follow)
- Added tests for `CreateShopSpotlightFeedItem` covering the null user case, normal approval, digest deduplication, and digest expiry

## Test plan

- [ ] Run `php artisan migrate` on production
- [ ] Approve a card shop that has no submitting user — should succeed without error
- [ ] Confirm the shop spotlight appears in the global feed