### PR TITLE
Fix stats-card crash from __PHP_Incomplete_Class on Carbon deserialization

### DIFF
--- a/app/Services/UserStatsService.php
+++ b/app/Services/UserStatsService.php
@@ -6,7 +6,6 @@ use App\Models\Feed;
 use App\Models\Player;
 use App\Models\PostalMail;
 use App\Models\User;
-use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
 
 class UserStatsService
@@ -105,8 +104,8 @@ class UserStatsService
             'total_returns' => $totalReturns,
             'success_rate' => $successRate,
             'unique_players' => $uniquePlayers,
-            'first_send' => $firstSend ? Carbon::parse($firstSend) : null,
-            'most_recent_return' => $mostRecentReturn ? Carbon::parse($mostRecentReturn) : null,
+            'first_send' => $firstSend,
+            'most_recent_return' => $mostRecentReturn,
             'fastest_return' => $fastest ? [
                 'player_name' => $fastest->player_name,
                 'player_slug' => $fastest->player_slug,

--- a/resources/views/components/stats-card.blade.php
+++ b/resources/views/components/stats-card.blade.php
@@ -84,7 +84,7 @@
                     <x-heroicon-o-paper-airplane class="size-4 sm:size-5 text-white/70 shrink-0" />
                     First Send
                 </div>
-                <span class="text-sm font-semibold text-right">{{ ($firstSend instanceof \Carbon\Carbon ? $firstSend : \Carbon\Carbon::parse($firstSend))->format('M j, Y') }}</span>
+                <span class="text-sm font-semibold text-right">{{ rescue(fn () => \Carbon\Carbon::parse($firstSend)->format('M j, Y'), '') }}</span>
             </div>
         @endif
         @if (data_get($stats, 'most_recent_return'))
@@ -94,7 +94,7 @@
                     <x-heroicon-o-inbox-arrow-down class="size-4 sm:size-5 text-white/70 shrink-0" />
                     Latest Return
                 </div>
-                <span class="text-sm font-semibold text-right">{{ ($latestReturn instanceof \Carbon\Carbon ? $latestReturn : \Carbon\Carbon::parse($latestReturn))->format('M j, Y') }}</span>
+                <span class="text-sm font-semibold text-right">{{ rescue(fn () => \Carbon\Carbon::parse($latestReturn)->format('M j, Y'), '') }}</span>
             </div>
         @endif
         @if (data_get($stats, 'total_sends', 0) === 0)

--- a/tests/Feature/Services/UserStatsServiceTest.php
+++ b/tests/Feature/Services/UserStatsServiceTest.php
@@ -1,0 +1,55 @@
+<?php
+
+use App\Models\PostalMail;
+use App\Models\User;
+use App\Services\UserStatsService;
+use Illuminate\Support\Facades\Cache;
+
+it('returns string dates, not Carbon objects, so they survive cache serialization', function () {
+    $user = User::factory()->create();
+    PostalMail::factory()->returned()->create(['user_id' => $user->id]);
+
+    $stats = app(UserStatsService::class)->compute($user);
+
+    expect($stats['first_send'])->toBeString();
+    expect($stats['most_recent_return'])->toBeString();
+});
+
+it('caches the result and returns the same values on subsequent calls', function () {
+    $user = User::factory()->create();
+    PostalMail::factory()->returned()->create(['user_id' => $user->id]);
+
+    $service = app(UserStatsService::class);
+    $first = $service->compute($user);
+    $second = $service->compute($user);
+
+    expect($second)->toBe($first);
+    expect(Cache::has("user_stats_{$user->id}"))->toBeTrue();
+});
+
+it('returns null dates when the user has no sends', function () {
+    $user = User::factory()->create();
+
+    $stats = app(UserStatsService::class)->compute($user);
+
+    expect($stats['first_send'])->toBeNull();
+    expect($stats['most_recent_return'])->toBeNull();
+});
+
+it('renders the profile page without error when stats contain date strings', function () {
+    $user = User::factory()->create();
+    PostalMail::factory()->returned()->create(['user_id' => $user->id]);
+
+    $this->get(route('users.profile', $user))->assertOk();
+});
+
+it('renders the profile page without error when stats are served from cache with date strings', function () {
+    $user = User::factory()->create();
+    PostalMail::factory()->returned()->create(['user_id' => $user->id]);
+
+    // Prime the cache
+    app(UserStatsService::class)->compute($user);
+
+    // Second request hits the cache
+    $this->get(route('users.profile', $user))->assertOk();
+});


### PR DESCRIPTION
## Summary

- `UserStatsService` was storing `Carbon` instances inside the cached stats array. When PHP deserializes that cache entry and the class isn't fully loaded yet, it produces `__PHP_Incomplete_Class`, causing `Carbon::parse()` to throw a `TypeError` in the `stats-card` blade.
- Fix: store the raw date strings returned by `min()`/`max()` instead of wrapping them in `Carbon::parse()` before caching. Strings serialize/deserialize safely.
- Add `rescue()` in the blade as a safety net for the ~5-minute transition window while stale cache entries (with the old Carbon objects) expire.

## Test plan

- [ ] New `tests/Feature/Services/UserStatsServiceTest.php` covers: dates are strings in the returned array, caching works, null dates for users with no sends, and profile page renders without error both on first load and from cache.
- [ ] Run `php artisan test --compact tests/Feature/Services/UserStatsServiceTest.php` — all 5 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)