### PR TITLE
Fix feed UX: mobile nav, return ordering, and comment expand

### DIFF
--- a/app/Livewire/UserFeed.php
+++ b/app/Livewire/UserFeed.php
@@ -37,7 +37,7 @@ class UserFeed extends Component
             )
             ->withCount('feedComments')
             ->with(['reactions', 'feedable'])
-            ->orderByDesc('created_at')
+            ->orderByDesc('updated_at')
             ->skip($this->offset)
             ->limit($this->perPage + 1);
 

--- a/resources/views/livewire/feed-comments.blade.php
+++ b/resources/views/livewire/feed-comments.blade.php
@@ -2,7 +2,7 @@
     {{-- Toggle row --}}
     <div class="flex items-center justify-between">
         @if ($this->commentCount > 0 && ! $expanded)
-            <p class="text-xs text-gray-400">{{ $this->commentCount }} {{ Str::plural('comment', $this->commentCount) }}</p>
+            <button wire:click="toggle" class="text-xs text-gray-400 hover:text-gray-600 transition-colors">{{ $this->commentCount }} {{ Str::plural('comment', $this->commentCount) }}</button>
         @else
             <span></span>
         @endif

--- a/resources/views/livewire/user-feed.blade.php
+++ b/resources/views/livewire/user-feed.blade.php
@@ -57,6 +57,50 @@
             {{-- Main content --}}
             <main class="flex-1 min-w-0 space-y-4">
 
+                {{-- Mobile user card + nav --}}
+                <div class="md:hidden">
+                    @auth
+                        <div class="flex items-center gap-4 mb-4">
+                            <img src="{{ $this->authUser->profile_photo_url }}" alt="{{ $this->authUser->name }}"
+                                 class="size-14 rounded-full shrink-0 ring-2 ring-gray-100" />
+                            <div class="min-w-0">
+                                <p class="font-bold text-gray-900 truncate">{{ $this->authUser->name }}</p>
+                                <div class="flex gap-4 mt-1 text-sm">
+                                    <span><span class="font-bold text-gray-900">{{ $this->authUser->following_count }}</span> <span class="text-gray-400 text-xs">Following</span></span>
+                                    <span><span class="font-bold text-gray-900">{{ $this->authUser->followers_count }}</span> <span class="text-gray-400 text-xs">Followers</span></span>
+                                </div>
+                            </div>
+                        </div>
+                        <nav class="flex gap-1 overflow-x-auto pb-1 -mx-1 px-1">
+                            <a href="{{ route('users.feed') }}"
+                               class="flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-medium whitespace-nowrap transition-colors shrink-0 {{ request()->routeIs('users.feed') ? 'bg-red-50 text-[#D93C3F]' : 'text-gray-500 hover:text-gray-800' }}">
+                                <x-heroicon-o-inbox class="size-4 shrink-0" /> Feed
+                            </a>
+                            <a href="{{ route('users.trending') }}"
+                               class="flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-medium whitespace-nowrap transition-colors shrink-0 {{ request()->routeIs('users.trending') ? 'bg-red-50 text-[#D93C3F]' : 'text-gray-500 hover:text-gray-800' }}">
+                                <x-heroicon-o-fire class="size-4 shrink-0" /> Trending
+                            </a>
+                            <a href="{{ route('packs.browse') }}"
+                               class="flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-medium whitespace-nowrap transition-colors shrink-0 {{ request()->routeIs('packs.*') ? 'bg-red-50 text-[#D93C3F]' : 'text-gray-500 hover:text-gray-800' }}">
+                                <x-heroicon-o-bookmark class="size-4 shrink-0" /> Packs
+                            </a>
+                            <a href="{{ route('sets.browse') }}"
+                               class="flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-medium whitespace-nowrap transition-colors shrink-0 {{ request()->routeIs('sets.*') ? 'bg-red-50 text-[#D93C3F]' : 'text-gray-500 hover:text-gray-800' }}">
+                                <x-heroicon-o-squares-2x2 class="size-4 shrink-0" /> Sets
+                            </a>
+                            <a href="{{ route('users.profile', auth()->user()) }}"
+                               class="flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-medium whitespace-nowrap transition-colors shrink-0 text-gray-500 hover:text-gray-800">
+                                <x-heroicon-o-user-circle class="size-4 shrink-0" /> My Profile
+                            </a>
+                        </nav>
+                    @else
+                        <div class="flex items-center justify-between mb-4">
+                            <p class="text-sm font-medium text-gray-700">Sign in to personalize your feed</p>
+                            <a href="{{ route('login') }}" class="text-sm font-semibold text-gray-900 underline underline-offset-2">Log in</a>
+                        </div>
+                    @endauth
+                </div>
+
                 {{-- Compose --}}
                 @auth
                     <livewire:feed-composer />


### PR DESCRIPTION
## Summary

- **Mobile nav**: Added a user card + scrollable nav strip (Feed, Trending, Packs, Sets, My Profile) at the top of the feed for mobile users — hidden on `md+` since the sidebar handles that. The Trending link has never been accessible on mobile.
- **Return ordering**: Feed now sorts by `updated_at` instead of `created_at`, so when a mailer return is logged and the feed item's meta is updated, it bubbles to the top as new activity.
- **Comment expand**: The "N comments" count text is now clickable and expands the comment thread inline, same as the "Reply" button.

## Test plan

- [ ] On mobile, verify user card and nav links appear above the feed
- [ ] Verify nav links are hidden on desktop (sidebar handles it)
- [ ] Log a return on an existing mailer and confirm its feed card sorts to the top
- [ ] Click "1 comment" on a feed card and confirm the thread expands

🤖 Generated with [Claude Code](https://claude.com/claude-code)